### PR TITLE
fix(xray): add Chinese descriptions to CLI help commands

### DIFF
--- a/products/xray/README.md
+++ b/products/xray/README.md
@@ -1,33 +1,33 @@
-# Xray CLI
+# 洞鉴(XRay) CLI
 
-命令行工具，用于通过 OpenAPI v2 控制 Xray 扫描平台。
+命令行工具，用于通过 OpenAPI v2 控制洞鉴(XRay)扫描平台。
 
 ## 命令列表
 
 | 命令 | 说明 |
 |------|------|
-| `asset_property` | 资产属性管理 |
-| `audit_log` | 审计日志 |
-| `baseline` | 基线检查 |
-| `custom_poc` | 自定义 PoC |
-| `domain_asset` | 域名资产管理 |
-| `insight` | 洞察分析 |
-| `ip_asset` | IP 资产管理 |
-| `plan` | 任务管理 |
-| `project` | 项目管理 |
-| `report` | 报告管理 |
-| `result` | 结果查询 |
-| `role` | 角色管理 |
-| `service_asset` | 服务资产管理 |
-| `system_info` | 系统信息 |
-| `system_service` | 系统服务 |
-| `task_config` | 任务配置 |
-| `template` | 策略模板 |
-| `user` | 用户管理 |
-| `vulnerability` | 漏洞管理 |
-| `web_asset` | Web 资产管理 |
-| `xprocess` | 扫描进程 |
-| `xprocess_lite` | 轻量级扫描进程 |
+| `cws xray asset_property` | 资产管理 |
+| `cws xray audit_log` | 审计日志管理 |
+| `cws xray baseline` | 基线检查管理 |
+| `cws xray custom_poc` | 自定义POC管理 |
+| `cws xray domain_asset` | 域名资产管理 |
+| `cws xray insight` | 数据洞察 |
+| `cws xray ip_asset` | 主机资产管理 |
+| `cws xray plan` | 任务计划管理 |
+| `cws xray project` | 工作区管理 |
+| `cws xray report` | 报表管理 |
+| `cws xray result` | 任务结果管理 |
+| `cws xray role` | 角色管理 |
+| `cws xray service_asset` | 服务资产管理 |
+| `cws xray system_info` | 系统信息管理 |
+| `cws xray system_service` | 系统服务管理 |
+| `cws xray task_config` | 任务配置管理 |
+| `cws xray template` | 策略模板管理 |
+| `cws xray user` | 用户管理 |
+| `cws xray vulnerability` | 漏洞资产管理 |
+| `cws xray web_asset` | Web资产管理 |
+| `cws xray xprocess` | XProcess任务实例管理 |
+| `cws xray xprocess_lite` | XProcess精简版管理 |
 
 ## 配置
 
@@ -53,7 +53,7 @@ xray:
 
 ### 创建任务 (PostPlanCreateQuick)
 
-快速创建扫描任务，自动使用"基础服务漏洞扫描"模板。
+快速创建扫描任务，立即执行（马上扫一次）。
 
 ```bash
 cws xray plan PostPlanCreateQuick \
@@ -69,8 +69,7 @@ cws xray plan PostPlanCreateQuick \
 | `--targets` | 是 | 扫描目标（逗号分隔） |
 | `--engines` | 是 | 引擎 ID（逗号分隔） |
 | `--project-id` | 是 | 项目 ID |
-| `--template-id` | 否 | 指定模板 ID（默认自动查找"基础服务漏洞扫描"） |
-| `--template-name` | 否 | 模板名称搜索关键字 |
+| `--template-name` | 否 | 模板名称搜索关键字（默认"基础服务漏洞扫描"） |
 | `--name` | 否 | 任务名称（默认 quick-scan） |
 
 ### 任务列表 (PostPlanFilter)

--- a/products/xray/cli/cli.go
+++ b/products/xray/cli/cli.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/chaitin/workspace-cli/config"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/chaitin/workspace-cli/products/xray/client"
 	"github.com/go-openapi/runtime"
@@ -78,7 +77,9 @@ func makeClient(cmd *cobra.Command, _ []string) (*client.OPENAPI, error) {
 func MakeCommand() (*cobra.Command, error) {
 	// Use "xray" as the command name for subcommand usage
 	rootCmd := &cobra.Command{
-		Use: "xray",
+		Use:   "xray",
+		Short: "洞鉴(XRay) 风险评估系统",
+		Long:  "洞鉴(XRay) 是一款自动化漏洞扫描与风险管理平台，支持资产发现、漏洞检测、基线检查、报告生成等功能。",
 	}
 
 	rootCmd.PersistentFlags().String("url", "", "API URL (e.g. https://api.example.com/api/v2)")
@@ -203,15 +204,6 @@ func MakeCommand() (*cobra.Command, error) {
 	}
 	rootCmd.AddCommand(c21)
 
-	// add cobra completion
-	rootCmd.AddCommand(makeGenCompletionCmd())
-
-	// add cobra markdown
-	markdownCmd := makeMarkdownDocumentationCmd()
-	rootCmd.AddCommand(markdownCmd)
-	markdownCmd.Flags().String("dir", "./markdown/", "The destination directory to save docs in")
-	_ = viper.BindPFlag("markdown_dir", markdownCmd.Flags().Lookup("dir"))
-
 	return rootCmd, nil
 }
 
@@ -295,7 +287,8 @@ func SetRuntimeConfig(cfg config.Raw, enabledDryRun bool) {
 func makeGroupOfOperationsAssetPropertyCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "asset_property",
-		Long: ``,
+		Short: `资产管理`,
+		Long: `资产管理`,
 	}
 
 	sub0, err := makeOperationAssetPropertyGetAssetGroupsProjectIDCmd()
@@ -369,7 +362,8 @@ func makeGroupOfOperationsAssetPropertyCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsAuditLogCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "audit_log",
-		Long: ``,
+		Short: `审计日志管理`,
+		Long: `审计日志管理`,
 	}
 
 	sub0, err := makeOperationAuditLogGetAuditlogActionCmd()
@@ -389,7 +383,8 @@ func makeGroupOfOperationsAuditLogCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsBaselineCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "baseline",
-		Long: ``,
+		Short: `基线检查管理`,
+		Long: `基线检查管理`,
 	}
 
 	sub0, err := makeOperationBaselinePostBaselineTaskCreateCmd()
@@ -445,7 +440,8 @@ func makeGroupOfOperationsBaselineCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsCustomPocCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "custom_poc",
-		Long: ``,
+		Short: `自定义POC管理`,
+		Long: `自定义POC管理`,
 	}
 
 	sub0, err := makeOperationCustomPocDeleteCustompocCmd()
@@ -495,7 +491,8 @@ func makeGroupOfOperationsCustomPocCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsDomainAssetCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "domain_asset",
-		Long: ``,
+		Short: `域名资产管理`,
+		Long: `域名资产管理`,
 	}
 
 	sub0, err := makeOperationDomainAssetDeleteDomainCmd()
@@ -539,7 +536,8 @@ func makeGroupOfOperationsDomainAssetCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsInsightCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "insight",
-		Long: ``,
+		Short: `数据洞察`,
+		Long: `数据洞察`,
 	}
 
 	sub0, err := makeOperationInsightPostAPIV2InsightAssetDeletedIPListCmd()
@@ -649,7 +647,8 @@ func makeGroupOfOperationsInsightCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsIPAssetCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "ip_asset",
-		Long: ``,
+		Short: `主机资产管理`,
+		Long: `主机资产管理`,
 	}
 
 	sub0, err := makeOperationIPAssetDeleteIPCmd()
@@ -693,7 +692,8 @@ func makeGroupOfOperationsIPAssetCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsPlanCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "plan",
-		Long: ``,
+		Short: `任务计划`,
+		Long: `任务计划`,
 	}
 
 	sub0, err := makeOperationPlanDeletePlanIDCmd()
@@ -708,48 +708,37 @@ func makeGroupOfOperationsPlanCmd() (*cobra.Command, error) {
 	}
 	parent.AddCommand(sub1)
 
-	sub2, err := makeOperationPlanPostPlanCreateCmd()
+	sub2, err := makeOperationPlanPostPlanExecuteCmd()
 	if err != nil {
 		return nil, err
 	}
 	parent.AddCommand(sub2)
 
-	sub3, err := makeOperationPlanPostPlanExecuteCmd()
+	sub3, err := makeOperationPlanPostPlanFilterCmd()
 	if err != nil {
 		return nil, err
 	}
 	parent.AddCommand(sub3)
 
-	sub4, err := makeOperationPlanPostPlanFilterCmd()
+	sub4, err := makeOperationPlanPostPlanStopCmd()
 	if err != nil {
 		return nil, err
 	}
 	parent.AddCommand(sub4)
 
-	sub5, err := makeOperationPlanPostPlanStopCmd()
+	sub5, err := makeOperationPlanCreateQuickCmd()
 	if err != nil {
 		return nil, err
 	}
 	parent.AddCommand(sub5)
-
-	sub6, err := makeOperationPlanPostPlanUpdateCmd()
-	if err != nil {
-		return nil, err
-	}
-	parent.AddCommand(sub6)
-
-	sub7, err := makeOperationPlanCreateQuickCmd()
-	if err != nil {
-		return nil, err
-	}
-	parent.AddCommand(sub7)
 
 	return parent, nil
 } // makeGroupOfOperationsProjectCmd returns a parent command to handle all operations with tag "project"
 func makeGroupOfOperationsProjectCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "project",
-		Long: ``,
+		Short: `工作区管理`,
+		Long: `工作区管理`,
 	}
 
 	sub0, err := makeOperationProjectGetProjectCmd()
@@ -787,7 +776,8 @@ func makeGroupOfOperationsProjectCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsReportCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "report",
-		Long: ``,
+		Short: `报表管理`,
+		Long: `报表管理`,
 	}
 
 	sub0, err := makeOperationReportDeleteReportIDCmd()
@@ -831,7 +821,8 @@ func makeGroupOfOperationsReportCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsResultCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "result",
-		Long: ``,
+		Short: `任务结果管理`,
+		Long: `任务结果管理`,
 	}
 
 	sub0, err := makeOperationResultGetResultIDCmd()
@@ -851,7 +842,8 @@ func makeGroupOfOperationsResultCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsRoleCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "role",
-		Long: ``,
+		Short: `角色管理`,
+		Long: `角色管理`,
 	}
 
 	sub0, err := makeOperationRolePostRoleCmd()
@@ -871,7 +863,8 @@ func makeGroupOfOperationsRoleCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsServiceAssetCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "service_asset",
-		Long: ``,
+		Short: `服务资产管理`,
+		Long: `服务资产管理`,
 	}
 
 	sub0, err := makeOperationServiceAssetDeleteServiceCmd()
@@ -915,7 +908,8 @@ func makeGroupOfOperationsServiceAssetCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsSystemInfoCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "system_info",
-		Long: ``,
+		Short: `系统信息管理`,
+		Long: `系统信息管理`,
 	}
 
 	sub0, err := makeOperationSystemInfoDeleteEngineIDCmd()
@@ -983,7 +977,8 @@ func makeGroupOfOperationsSystemInfoCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsSystemServiceCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "system_service",
-		Long: ``,
+		Short: `系统服务管理`,
+		Long: `系统服务管理`,
 	}
 
 	sub0, err := makeOperationSystemServicePostEngineUpgradeCmd()
@@ -1027,7 +1022,8 @@ func makeGroupOfOperationsSystemServiceCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsTaskConfigCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "task_config",
-		Long: ``,
+		Short: `任务配置管理`,
+		Long: `任务配置管理`,
 	}
 
 	sub0, err := makeOperationTaskConfigDeleteScannerdictCmd()
@@ -1155,7 +1151,8 @@ func makeGroupOfOperationsTaskConfigCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsTemplateCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "template",
-		Long: ``,
+		Short: `策略模板管理`,
+		Long: `策略模板管理`,
 	}
 
 	sub0, err := makeOperationTemplateGetTemplateCmd()
@@ -1181,7 +1178,8 @@ func makeGroupOfOperationsTemplateCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsUserCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "user",
-		Long: ``,
+		Short: `用户管理`,
+		Long: `用户管理`,
 	}
 
 	sub0, err := makeOperationUserDeleteUserIDCmd()
@@ -1237,7 +1235,8 @@ func makeGroupOfOperationsUserCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsVulnerabilityCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "vulnerability",
-		Long: ``,
+		Short: `漏洞资产管理`,
+		Long: `漏洞资产管理`,
 	}
 
 	sub0, err := makeOperationVulnerabilityDeleteVulnCmd()
@@ -1305,7 +1304,8 @@ func makeGroupOfOperationsVulnerabilityCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsWebAssetCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "web_asset",
-		Long: ``,
+		Short: `Web资产管理`,
+		Long: `Web资产管理`,
 	}
 
 	sub0, err := makeOperationWebAssetDeleteWebsiteCmd()
@@ -1355,7 +1355,8 @@ func makeGroupOfOperationsWebAssetCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsXprocessCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "xprocess",
-		Long: ``,
+		Short: `XProcess任务实例管理`,
+		Long: `XProcess任务实例管理`,
 	}
 
 	sub0, err := makeOperationXprocessGetXprocessIDCmd()
@@ -1417,7 +1418,8 @@ func makeGroupOfOperationsXprocessCmd() (*cobra.Command, error) {
 func makeGroupOfOperationsXprocessLiteCmd() (*cobra.Command, error) {
 	parent := &cobra.Command{
 		Use:  "xprocess_lite",
-		Long: ``,
+		Short: `XProcess精简版管理`,
+		Long: `XProcess精简版管理`,
 	}
 
 	sub0, err := makeOperationXprocessLitePostXprocessLiteFilterCmd()

--- a/products/xray/cli/delete_custompoc_operation.go
+++ b/products/xray/cli/delete_custompoc_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationCustomPocDeleteCustompocCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeleteCustompoc",
-		Short: ``,
+		Short: `删除自定义poc`,
 		RunE:  runOperationCustomPocDeleteCustompoc,
 	}
 

--- a/products/xray/cli/delete_domain_operation.go
+++ b/products/xray/cli/delete_domain_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationDomainAssetDeleteDomainCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeleteDomain",
-		Short: ``,
+		Short: `批量删除域名`,
 		RunE:  runOperationDomainAssetDeleteDomain,
 	}
 

--- a/products/xray/cli/delete_engine_id_operation.go
+++ b/products/xray/cli/delete_engine_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationSystemInfoDeleteEngineIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeleteEngineID",
-		Short: ``,
+		Short: `删除引擎，仅超级管理员可进行此操作`,
 		RunE:  runOperationSystemInfoDeleteEngineID,
 	}
 

--- a/products/xray/cli/delete_ip_operation.go
+++ b/products/xray/cli/delete_ip_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationIPAssetDeleteIPCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeleteIP",
-		Short: ``,
+		Short: `批量删除主机`,
 		RunE:  runOperationIPAssetDeleteIP,
 	}
 

--- a/products/xray/cli/delete_plan_id_operation.go
+++ b/products/xray/cli/delete_plan_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationPlanDeletePlanIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeletePlanID",
-		Short: ``,
+		Short: `删除任务`,
 		RunE:  runOperationPlanDeletePlanID,
 	}
 

--- a/products/xray/cli/delete_report_id_operation.go
+++ b/products/xray/cli/delete_report_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationReportDeleteReportIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeleteReportID",
-		Short: ``,
+		Short: `删除报表`,
 		RunE:  runOperationReportDeleteReportID,
 	}
 

--- a/products/xray/cli/delete_service_operation.go
+++ b/products/xray/cli/delete_service_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationServiceAssetDeleteServiceCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeleteService",
-		Short: ``,
+		Short: `批量删除服务`,
 		RunE:  runOperationServiceAssetDeleteService,
 	}
 

--- a/products/xray/cli/delete_user_id_operation.go
+++ b/products/xray/cli/delete_user_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationUserDeleteUserIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeleteUserID",
-		Short: ``,
+		Short: `删除用户`,
 		RunE:  runOperationUserDeleteUserID,
 	}
 

--- a/products/xray/cli/delete_vuln_operation.go
+++ b/products/xray/cli/delete_vuln_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationVulnerabilityDeleteVulnCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeleteVuln",
-		Short: ``,
+		Short: `批量删除漏洞资产`,
 		RunE:  runOperationVulnerabilityDeleteVuln,
 	}
 

--- a/products/xray/cli/delete_website_operation.go
+++ b/products/xray/cli/delete_website_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationWebAssetDeleteWebsiteCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "DeleteWebsite",
-		Short: ``,
+		Short: `批量删除 Web 站点`,
 		RunE:  runOperationWebAssetDeleteWebsite,
 	}
 

--- a/products/xray/cli/get_asset_tag_id_operation.go
+++ b/products/xray/cli/get_asset_tag_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationAssetPropertyGetAssetTagIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetAssetTagID",
-		Short: ``,
+		Short: `获取资产标签详情`,
 		RunE:  runOperationAssetPropertyGetAssetTagID,
 	}
 

--- a/products/xray/cli/get_business_system_id_operation.go
+++ b/products/xray/cli/get_business_system_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationAssetPropertyGetBusinessSystemIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetBusinessSystemID",
-		Short: ``,
+		Short: `获取业务系统详情`,
 		RunE:  runOperationAssetPropertyGetBusinessSystemID,
 	}
 

--- a/products/xray/cli/get_custom_plugin_id_operation.go
+++ b/products/xray/cli/get_custom_plugin_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationTaskConfigGetCustomPluginIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetCustomPluginID",
-		Short: ``,
+		Short: `获取自定义插件详情`,
 		RunE:  runOperationTaskConfigGetCustomPluginID,
 	}
 

--- a/products/xray/cli/get_domain_id_operation.go
+++ b/products/xray/cli/get_domain_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationDomainAssetGetDomainIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetDomainID",
-		Short: ``,
+		Short: `获取域名资产`,
 		RunE:  runOperationDomainAssetGetDomainID,
 	}
 

--- a/products/xray/cli/get_ip_id_operation.go
+++ b/products/xray/cli/get_ip_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationIPAssetGetIPIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetIPID",
-		Short: ``,
+		Short: `获取主机资产`,
 		RunE:  runOperationIPAssetGetIPID,
 	}
 

--- a/products/xray/cli/get_location_id_operation.go
+++ b/products/xray/cli/get_location_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationAssetPropertyGetLocationIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetLocationID",
-		Short: ``,
+		Short: `获取行政规划区域详情`,
 		RunE:  runOperationAssetPropertyGetLocationID,
 	}
 

--- a/products/xray/cli/get_network_region_id_operation.go
+++ b/products/xray/cli/get_network_region_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationAssetPropertyGetNetworkRegionIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetNetworkRegionID",
-		Short: ``,
+		Short: `获取网络区域详情`,
 		RunE:  runOperationAssetPropertyGetNetworkRegionID,
 	}
 

--- a/products/xray/cli/get_plan_id_operation.go
+++ b/products/xray/cli/get_plan_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationPlanGetPlanIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetPlanID",
-		Short: ``,
+		Short: `获取任务计划`,
 		RunE:  runOperationPlanGetPlanID,
 	}
 

--- a/products/xray/cli/get_project_id_operation.go
+++ b/products/xray/cli/get_project_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationProjectGetProjectIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetProjectID",
-		Short: ``,
+		Short: `获取工作区详情`,
 		RunE:  runOperationProjectGetProjectID,
 	}
 

--- a/products/xray/cli/get_project_operation.go
+++ b/products/xray/cli/get_project_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationProjectGetProjectCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetProject",
-		Short: ``,
+		Short: `获取工作区列表`,
 		RunE:  runOperationProjectGetProject,
 	}
 

--- a/products/xray/cli/get_report_id_operation.go
+++ b/products/xray/cli/get_report_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationReportGetReportIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetReportID",
-		Short: ``,
+		Short: `查询报表详细信息`,
 		RunE:  runOperationReportGetReportID,
 	}
 

--- a/products/xray/cli/get_result_id_operation.go
+++ b/products/xray/cli/get_result_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationResultGetResultIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetResultID",
-		Short: ``,
+		Short: `获取任务结果`,
 		RunE:  runOperationResultGetResultID,
 	}
 

--- a/products/xray/cli/get_reverse_platform_uuid_operation.go
+++ b/products/xray/cli/get_reverse_platform_uuid_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationTaskConfigGetReversePlatformUUIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetReversePlatformUUID",
-		Short: ``,
+		Short: `根据反连平台的 uuid 获取反连平台的详细信息`,
 		RunE:  runOperationTaskConfigGetReversePlatformUUID,
 	}
 

--- a/products/xray/cli/get_scannerdict_id_operation.go
+++ b/products/xray/cli/get_scannerdict_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationTaskConfigGetScannerdictIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetScannerdictID",
-		Short: ``,
+		Short: `获取字典详情`,
 		RunE:  runOperationTaskConfigGetScannerdictID,
 	}
 

--- a/products/xray/cli/get_service_id_operation.go
+++ b/products/xray/cli/get_service_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationServiceAssetGetServiceIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetServiceID",
-		Short: ``,
+		Short: `获取服务资产`,
 		RunE:  runOperationServiceAssetGetServiceID,
 	}
 

--- a/products/xray/cli/get_system_dns_engine_id_operation.go
+++ b/products/xray/cli/get_system_dns_engine_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationSystemInfoGetSystemDNSEngineIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetSystemDNSEngineID",
-		Short: ``,
+		Short: `获取指定引擎的 dns 配置`,
 		RunE:  runOperationSystemInfoGetSystemDNSEngineID,
 	}
 

--- a/products/xray/cli/get_system_hosts_engine_id_operation.go
+++ b/products/xray/cli/get_system_hosts_engine_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationSystemInfoGetSystemHostsEngineIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetSystemHostsEngineID",
-		Short: ``,
+		Short: `获取指定引擎的 hosts 配置`,
 		RunE:  runOperationSystemInfoGetSystemHostsEngineID,
 	}
 

--- a/products/xray/cli/get_system_info_mgmt_operation.go
+++ b/products/xray/cli/get_system_info_mgmt_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationSystemInfoGetSystemInfoMgmtCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetSystemInfoMgmt",
-		Short: ``,
+		Short: `查询管理节点系统信息和负载信息`,
 		RunE:  runOperationSystemInfoGetSystemInfoMgmt,
 	}
 

--- a/products/xray/cli/get_system_info_services_operation.go
+++ b/products/xray/cli/get_system_info_services_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationSystemInfoGetSystemInfoServicesCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetSystemInfoServices",
-		Short: ``,
+		Short: `查询管理节点服务容器名`,
 		RunE:  runOperationSystemInfoGetSystemInfoServices,
 	}
 

--- a/products/xray/cli/get_template_id_operation.go
+++ b/products/xray/cli/get_template_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationTemplateGetTemplateIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetTemplateID",
-		Short: ``,
+		Short: `获取策略模板`,
 		RunE:  runOperationTemplateGetTemplateID,
 	}
 

--- a/products/xray/cli/get_vuln_id_operation.go
+++ b/products/xray/cli/get_vuln_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationVulnerabilityGetVulnIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetVulnID",
-		Short: ``,
+		Short: `获取漏洞资产`,
 		RunE:  runOperationVulnerabilityGetVulnID,
 	}
 

--- a/products/xray/cli/get_vuln_library_info_operation.go
+++ b/products/xray/cli/get_vuln_library_info_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationSystemInfoGetVulnLibraryInfoCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetVulnLibraryInfo",
-		Short: ``,
+		Short: `查询漏洞库信息（版本、总数、最近更新时间）`,
 		RunE:  runOperationSystemInfoGetVulnLibraryInfo,
 	}
 

--- a/products/xray/cli/get_vuln_retest_task_id_operation.go
+++ b/products/xray/cli/get_vuln_retest_task_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationVulnerabilityGetVulnRetestTaskIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetVulnRetestTaskID",
-		Short: ``,
+		Short: `漏洞资产复测结果获取`,
 		RunE:  runOperationVulnerabilityGetVulnRetestTaskID,
 	}
 

--- a/products/xray/cli/get_website_id_operation.go
+++ b/products/xray/cli/get_website_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationWebAssetGetWebsiteIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetWebsiteID",
-		Short: ``,
+		Short: `获取 Web 站点`,
 		RunE:  runOperationWebAssetGetWebsiteID,
 	}
 

--- a/products/xray/cli/get_website_openapi_id_operation.go
+++ b/products/xray/cli/get_website_openapi_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationWebAssetGetWebsiteOpenapiIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetWebsiteOpenapiID",
-		Short: ``,
+		Short: `获取 API 资产`,
 		RunE:  runOperationWebAssetGetWebsiteOpenapiID,
 	}
 

--- a/products/xray/cli/get_whitelist_id_operation.go
+++ b/products/xray/cli/get_whitelist_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationTaskConfigGetWhitelistIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetWhitelistID",
-		Short: ``,
+		Short: `获取全局白名单详情`,
 		RunE:  runOperationTaskConfigGetWhitelistID,
 	}
 

--- a/products/xray/cli/get_xprocess_id_info_operation.go
+++ b/products/xray/cli/get_xprocess_id_info_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationXprocessGetXprocessIDInfoCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetXprocessIDInfo",
-		Short: ``,
+		Short: `获取任务实例信息`,
 		RunE:  runOperationXprocessGetXprocessIDInfo,
 	}
 

--- a/products/xray/cli/get_xprocess_id_operation.go
+++ b/products/xray/cli/get_xprocess_id_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationXprocessGetXprocessIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "GetXprocessID",
-		Short: ``,
+		Short: `获取任务实例`,
 		RunE:  runOperationXprocessGetXprocessID,
 	}
 

--- a/products/xray/cli/post_account_change_self_passwd_operation.go
+++ b/products/xray/cli/post_account_change_self_passwd_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationUserPostAccountChangeSelfPasswdCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostAccountChangeSelfPasswd",
-		Short: ``,
+		Short: `修改自己密码`,
 		RunE:  runOperationUserPostAccountChangeSelfPasswd,
 	}
 

--- a/products/xray/cli/post_account_change_someone_passwd_without_token_operation.go
+++ b/products/xray/cli/post_account_change_someone_passwd_without_token_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationUserPostAccountChangeSomeonePasswdWithoutTokenCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostAccountChangeSomeonePasswdWithoutToken",
-		Short: ``,
+		Short: `修改某人密码,不使用api-token,使用自己的登录密码验证权限`,
 		RunE:  runOperationUserPostAccountChangeSomeonePasswdWithoutToken,
 	}
 

--- a/products/xray/cli/post_account_reset_user_passwd_operation.go
+++ b/products/xray/cli/post_account_reset_user_passwd_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationUserPostAccountResetUserPasswdCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostAccountResetUserPasswd",
-		Short: ``,
+		Short: `修改用户密码`,
 		RunE:  runOperationUserPostAccountResetUserPasswd,
 	}
 

--- a/products/xray/cli/post_asset_tag_filter_operation.go
+++ b/products/xray/cli/post_asset_tag_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationAssetPropertyPostAssetTagFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostAssetTagFilter",
-		Short: ``,
+		Short: `筛选资产标签`,
 		RunE:  runOperationAssetPropertyPostAssetTagFilter,
 	}
 

--- a/products/xray/cli/post_auditlog_filter_operation.go
+++ b/products/xray/cli/post_auditlog_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationAuditLogPostAuditlogFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostAuditlogFilter",
-		Short: ``,
+		Short: `按条件批量获取审计日志`,
 		RunE:  runOperationAuditLogPostAuditlogFilter,
 	}
 

--- a/products/xray/cli/post_baseline_task_create_operation.go
+++ b/products/xray/cli/post_baseline_task_create_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationBaselinePostBaselineTaskCreateCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostBaselineTaskCreate",
-		Short: ``,
+		Short: `创建基线任务，仅支持在线检查`,
 		RunE:  runOperationBaselinePostBaselineTaskCreate,
 	}
 

--- a/products/xray/cli/post_baseline_task_execute_operation.go
+++ b/products/xray/cli/post_baseline_task_execute_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationBaselinePostBaselineTaskExecuteCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostBaselineTaskExecute",
-		Short: ``,
+		Short: `触发基线任务（马上扫一次）`,
 		RunE:  runOperationBaselinePostBaselineTaskExecute,
 	}
 

--- a/products/xray/cli/post_baseline_task_filter_operation.go
+++ b/products/xray/cli/post_baseline_task_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationBaselinePostBaselineTaskFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostBaselineTaskFilter",
-		Short: ``,
+		Short: `按条件批量获取任务`,
 		RunE:  runOperationBaselinePostBaselineTaskFilter,
 	}
 

--- a/products/xray/cli/post_baseline_task_stop_operation.go
+++ b/products/xray/cli/post_baseline_task_stop_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationBaselinePostBaselineTaskStopCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostBaselineTaskStop",
-		Short: ``,
+		Short: `停止基线任务`,
 		RunE:  runOperationBaselinePostBaselineTaskStop,
 	}
 

--- a/products/xray/cli/post_business_system_filter_operation.go
+++ b/products/xray/cli/post_business_system_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationAssetPropertyPostBusinessSystemFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostBusinessSystemFilter",
-		Short: ``,
+		Short: `筛选业务系统`,
 		RunE:  runOperationAssetPropertyPostBusinessSystemFilter,
 	}
 

--- a/products/xray/cli/post_check_sets_filter_operation.go
+++ b/products/xray/cli/post_check_sets_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationBaselinePostCheckSetsFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostCheckSetsFilter",
-		Short: ``,
+		Short: `按条件批量获取检查策略列表`,
 		RunE:  runOperationBaselinePostCheckSetsFilter,
 	}
 

--- a/products/xray/cli/post_custom_plugin_filter_operation.go
+++ b/products/xray/cli/post_custom_plugin_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationTaskConfigPostCustomPluginFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostCustomPluginFilter",
-		Short: ``,
+		Short: `获取自定义插件列表`,
 		RunE:  runOperationTaskConfigPostCustomPluginFilter,
 	}
 

--- a/products/xray/cli/post_custompoc_filter_operation.go
+++ b/products/xray/cli/post_custompoc_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationCustomPocPostCustompocFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostCustompocFilter",
-		Short: ``,
+		Short: `筛选自定义poc`,
 		RunE:  runOperationCustomPocPostCustompocFilter,
 	}
 

--- a/products/xray/cli/post_custompoc_operation.go
+++ b/products/xray/cli/post_custompoc_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationCustomPocPostCustompocCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostCustompoc",
-		Short: ``,
+		Short: `创建自定义poc`,
 		RunE:  runOperationCustomPocPostCustompoc,
 	}
 

--- a/products/xray/cli/post_custompoc_update_operation.go
+++ b/products/xray/cli/post_custompoc_update_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationCustomPocPostCustompocUpdateCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostCustompocUpdate",
-		Short: ``,
+		Short: `更新自定义poc`,
 		RunE:  runOperationCustomPocPostCustompocUpdate,
 	}
 

--- a/products/xray/cli/post_domain_filter_simple_operation.go
+++ b/products/xray/cli/post_domain_filter_simple_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationDomainAssetPostDomainFilterSimpleCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostDomainFilterSimple",
-		Short: ``,
+		Short: `按条件批量获取精简的域名`,
 		RunE:  runOperationDomainAssetPostDomainFilterSimple,
 	}
 

--- a/products/xray/cli/post_domain_id_operation.go
+++ b/products/xray/cli/post_domain_id_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationDomainAssetPostDomainIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostDomainID",
-		Short: ``,
+		Short: `修改域名资产`,
 		RunE:  runOperationDomainAssetPostDomainID,
 	}
 

--- a/products/xray/cli/post_domain_operation.go
+++ b/products/xray/cli/post_domain_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationDomainAssetPostDomainCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostDomain",
-		Short: ``,
+		Short: `批量增加域名`,
 		RunE:  runOperationDomainAssetPostDomain,
 	}
 

--- a/products/xray/cli/post_engine_filter_operation.go
+++ b/products/xray/cli/post_engine_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationTaskConfigPostEngineFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostEngineFilter",
-		Short: ``,
+		Short: `获取引擎节点列表`,
 		RunE:  runOperationTaskConfigPostEngineFilter,
 	}
 

--- a/products/xray/cli/post_engine_upgrade_operation.go
+++ b/products/xray/cli/post_engine_upgrade_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationSystemServicePostEngineUpgradeCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostEngineUpgrade",
-		Short: ``,
+		Short: `引擎升级，请确保升级包校验通过`,
 		RunE:  runOperationSystemServicePostEngineUpgrade,
 	}
 

--- a/products/xray/cli/post_execution_filter_operation.go
+++ b/products/xray/cli/post_execution_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationSystemServicePostExecutionFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostExecutionFilter",
-		Short: ``,
+		Short: `执行状态列表`,
 		RunE:  runOperationSystemServicePostExecutionFilter,
 	}
 

--- a/products/xray/cli/post_hostlogrule_filter_operation.go
+++ b/products/xray/cli/post_hostlogrule_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationTaskConfigPostHostlogruleFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostHostlogruleFilter",
-		Short: ``,
+		Short: `获取日志解析规则列表`,
 		RunE:  runOperationTaskConfigPostHostlogruleFilter,
 	}
 

--- a/products/xray/cli/post_ip_filter_operation.go
+++ b/products/xray/cli/post_ip_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationIPAssetPostIPFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostIPFilter",
-		Short: ``,
+		Short: `按条件批量获取主机`,
 		RunE:  runOperationIPAssetPostIPFilter,
 	}
 

--- a/products/xray/cli/post_ip_id_operation.go
+++ b/products/xray/cli/post_ip_id_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationIPAssetPostIPIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostIPID",
-		Short: ``,
+		Short: `修改主机资产`,
 		RunE:  runOperationIPAssetPostIPID,
 	}
 

--- a/products/xray/cli/post_ip_operation.go
+++ b/products/xray/cli/post_ip_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationIPAssetPostIPCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostIP",
-		Short: ``,
+		Short: `批量增加主机`,
 		RunE:  runOperationIPAssetPostIP,
 	}
 

--- a/products/xray/cli/post_location_filter_operation.go
+++ b/products/xray/cli/post_location_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationAssetPropertyPostLocationFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostLocationFilter",
-		Short: ``,
+		Short: `筛选行政区域规划位置`,
 		RunE:  runOperationAssetPropertyPostLocationFilter,
 	}
 

--- a/products/xray/cli/post_network_region_filter_operation.go
+++ b/products/xray/cli/post_network_region_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationAssetPropertyPostNetworkRegionFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostNetworkRegionFilter",
-		Short: ``,
+		Short: `筛选网络区域`,
 		RunE:  runOperationAssetPropertyPostNetworkRegionFilter,
 	}
 

--- a/products/xray/cli/post_package_check_operation.go
+++ b/products/xray/cli/post_package_check_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationSystemServicePostPackageCheckCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPackageCheck",
-		Short: ``,
+		Short: `升级包校验`,
 		RunE:  runOperationSystemServicePostPackageCheck,
 	}
 

--- a/products/xray/cli/post_plan_create_operation.go
+++ b/products/xray/cli/post_plan_create_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationPlanPostPlanCreateCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPlanCreate",
-		Short: ``,
+		Short: `创建任务计划`,
 		RunE:  runOperationPlanPostPlanCreate,
 	}
 

--- a/products/xray/cli/post_plan_execute_operation.go
+++ b/products/xray/cli/post_plan_execute_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationPlanPostPlanExecuteCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPlanExecute",
-		Short: ``,
+		Short: `触发任务计划`,
 		RunE:  runOperationPlanPostPlanExecute,
 	}
 

--- a/products/xray/cli/post_plan_filter_operation.go
+++ b/products/xray/cli/post_plan_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationPlanPostPlanFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPlanFilter",
-		Short: ``,
+		Short: `按条件批量获取任务计划`,
 		RunE:  runOperationPlanPostPlanFilter,
 	}
 

--- a/products/xray/cli/post_plan_quick_operation.go
+++ b/products/xray/cli/post_plan_quick_operation.go
@@ -19,23 +19,22 @@ const defaultBuiltinTemplateName = "基础服务漏洞扫描"
 func makeOperationPlanCreateQuickCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPlanCreateQuick",
-		Short: "Quick create a plan with targets and engines",
-		Long: fmt.Sprintf(`Quick create a plan that runs immediately with specified targets and engines.
+		Short: "快速创建扫描任务（马上扫一次）",
+		Long: fmt.Sprintf(`快速创建扫描任务，立即执行。
 
-Example:
-  xray plan quick --targets=example.com --engines=00000000000000000000000000000001
-  xray plan quick --targets=example.com,example2.com --engines=engine1,engine2 --name=my-scan
+示例：
+  xray plan quick --targets=example.com --engines=00000000000000000000000000000001 --project-id=1
+  xray plan quick --targets=example.com,example2.com --engines=engine1,engine2 --name=my-scan --project-id=1
 
-The template-id defaults to the "%s" (BUILTIN) template.`, defaultBuiltinTemplateName),
+默认使用"基础服务漏洞扫描"(BUILTIN)模板。`),
 		RunE: runOperationPlanQuick,
 	}
 
-	cmd.Flags().String("targets", "", "Comma-separated list of targets (required)")
-	cmd.Flags().String("engines", "", "Comma-separated list of engine IDs (required)")
-	cmd.Flags().String("name", "quick-scan", "Task name")
-	cmd.Flags().Int64("project-id", 0, "Project ID")
-	cmd.Flags().Int64("template-id", 0, fmt.Sprintf("Task template ID (defaults to %s)", defaultBuiltinTemplateName))
-	cmd.Flags().String("template-name", "", fmt.Sprintf("Override template name search (default: %s)", defaultBuiltinTemplateName))
+	cmd.Flags().String("targets", "", "目标地址，逗号分隔 (必填)")
+	cmd.Flags().String("engines", "", "引擎 ID 列表，逗号分隔 (必填)")
+	cmd.Flags().String("name", "quick-scan", "任务名称")
+	cmd.Flags().Int64("project-id", 0, "工作区 ID (必填)")
+	cmd.Flags().String("template-name", "", fmt.Sprintf("模板名称 (默认: %s)", defaultBuiltinTemplateName))
 
 	return cmd, nil
 }
@@ -50,7 +49,6 @@ func runOperationPlanQuick(cmd *cobra.Command, args []string) error {
 	enginesStr, _ := cmd.Flags().GetString("engines")
 	name, _ := cmd.Flags().GetString("name")
 	projectID, _ := cmd.Flags().GetInt64("project-id")
-	templateID, _ := cmd.Flags().GetInt64("template-id")
 	templateNameFlag, _ := cmd.Flags().GetString("template-name")
 
 	targets := strings.Split(targetsStr, ",")
@@ -67,28 +65,19 @@ func runOperationPlanQuick(cmd *cobra.Command, args []string) error {
 	}
 
 	// Find template and get task_setting
-	var taskSetting interface{}
-	if templateID == 0 {
-		templateName := templateNameFlag
-		if templateName == "" {
-			templateName = defaultBuiltinTemplateName
-		}
-
-		templateID, taskSetting, err = findBuiltinTemplateWithTaskSetting(appCli, templateName)
-		if err != nil {
-			return err
-		}
-		if templateID == 0 {
-			return fmt.Errorf("template '%s' not found. Use --template-id to specify explicitly", templateName)
-		}
-		logDebugf("Found template ID %d for '%s'", templateID, templateName)
-	} else {
-		// When template-id is explicitly specified, fetch its task_setting
-		taskSetting, err = getTemplateTaskSetting(appCli, templateID)
-		if err != nil {
-			return err
-		}
+	templateName := templateNameFlag
+	if templateName == "" {
+		templateName = defaultBuiltinTemplateName
 	}
+
+	templateID, taskSetting, err := findBuiltinTemplateWithTaskSetting(appCli, templateName)
+	if err != nil {
+		return err
+	}
+	if templateID == 0 {
+		return fmt.Errorf("未找到模板: %s", templateName)
+	}
+	logDebugf("Found template ID %d for '%s'", templateID, templateName)
 
 	// Build basic_setting
 	basicSetting := map[string]interface{}{

--- a/products/xray/cli/post_plan_stop_operation.go
+++ b/products/xray/cli/post_plan_stop_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationPlanPostPlanStopCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPlanStop",
-		Short: ``,
+		Short: `停止任务计划（循环任务停止循环，不影响当前正在扫描的状态）`,
 		RunE:  runOperationPlanPostPlanStop,
 	}
 

--- a/products/xray/cli/post_plan_update_operation.go
+++ b/products/xray/cli/post_plan_update_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationPlanPostPlanUpdateCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPlanUpdate",
-		Short: ``,
+		Short: `更新任务计划`,
 		RunE:  runOperationPlanPostPlanUpdate,
 	}
 

--- a/products/xray/cli/post_plugin_filter_operation.go
+++ b/products/xray/cli/post_plugin_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationTaskConfigPostPluginFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPluginFilter",
-		Short: ``,
+		Short: `获取插件列表`,
 		RunE:  runOperationTaskConfigPostPluginFilter,
 	}
 

--- a/products/xray/cli/post_portgroup_filter_operation.go
+++ b/products/xray/cli/post_portgroup_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationTaskConfigPostPortgroupFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPortgroupFilter",
-		Short: ``,
+		Short: `获取端口组列表`,
 		RunE:  runOperationTaskConfigPostPortgroupFilter,
 	}
 

--- a/products/xray/cli/post_process_item_filter_operation.go
+++ b/products/xray/cli/post_process_item_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationBaselinePostProcessItemFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostProcessItemFilter",
-		Short: ``,
+		Short: `按条件批量获取检查项结果`,
 		RunE:  runOperationBaselinePostProcessItemFilter,
 	}
 

--- a/products/xray/cli/post_project_filter_operation.go
+++ b/products/xray/cli/post_project_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationProjectPostProjectFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostProjectFilter",
-		Short: ``,
+		Short: `根据 ancestor_project_id 筛选其所有下级工作区，不包括自己本身。根据full_name筛选特定工作区。`,
 		RunE:  runOperationProjectPostProjectFilter,
 	}
 

--- a/products/xray/cli/post_project_operation.go
+++ b/products/xray/cli/post_project_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationProjectPostProjectCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostProject",
-		Short: ``,
+		Short: `创建工作区`,
 		RunE:  runOperationProjectPostProject,
 	}
 

--- a/products/xray/cli/post_report_download_operation.go
+++ b/products/xray/cli/post_report_download_operation.go
@@ -19,7 +19,7 @@ import (
 func makeOperationReportPostReportDownloadCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostReportDownload",
-		Short: ``,
+		Short: `下载报表`,
 		RunE:  runOperationReportPostReportDownload,
 	}
 

--- a/products/xray/cli/post_report_filter_operation.go
+++ b/products/xray/cli/post_report_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationReportPostReportFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostReportFilter",
-		Short: ``,
+		Short: `按条件批量获取报表`,
 		RunE:  runOperationReportPostReportFilter,
 	}
 

--- a/products/xray/cli/post_report_operation.go
+++ b/products/xray/cli/post_report_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationReportPostReportCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostReport",
-		Short: ``,
+		Short: `创建报表`,
 		RunE:  runOperationReportPostReport,
 	}
 

--- a/products/xray/cli/post_report_template_filter_operation.go
+++ b/products/xray/cli/post_report_template_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationReportPostReportTemplateFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostReportTemplateFilter",
-		Short: ``,
+		Short: `按条件批量获取报表模板`,
 		RunE:  runOperationReportPostReportTemplateFilter,
 	}
 

--- a/products/xray/cli/post_result_filter_operation.go
+++ b/products/xray/cli/post_result_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationResultPostResultFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostResultFilter",
-		Short: ``,
+		Short: `按条件批量获取任务结果,注意 类型为 application 时不支持时间筛选`,
 		RunE:  runOperationResultPostResultFilter,
 	}
 

--- a/products/xray/cli/post_reverse_platform_filter_operation.go
+++ b/products/xray/cli/post_reverse_platform_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationTaskConfigPostReversePlatformFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostReversePlatformFilter",
-		Short: ``,
+		Short: `获取反连平台列表`,
 		RunE:  runOperationTaskConfigPostReversePlatformFilter,
 	}
 

--- a/products/xray/cli/post_role_filter_operation.go
+++ b/products/xray/cli/post_role_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationRolePostRoleFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostRoleFilter",
-		Short: ``,
+		Short: `根据角色名称筛选角色信息。`,
 		RunE:  runOperationRolePostRoleFilter,
 	}
 

--- a/products/xray/cli/post_role_operation.go
+++ b/products/xray/cli/post_role_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationRolePostRoleCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostRole",
-		Short: ``,
+		Short: `创建角色`,
 		RunE:  runOperationRolePostRole,
 	}
 

--- a/products/xray/cli/post_scannerdict_filter_operation.go
+++ b/products/xray/cli/post_scannerdict_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationTaskConfigPostScannerdictFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostScannerdictFilter",
-		Short: ``,
+		Short: `获取字典列表`,
 		RunE:  runOperationTaskConfigPostScannerdictFilter,
 	}
 

--- a/products/xray/cli/post_service_filter_operation.go
+++ b/products/xray/cli/post_service_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationServiceAssetPostServiceFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostServiceFilter",
-		Short: ``,
+		Short: `按条件批量获取服务`,
 		RunE:  runOperationServiceAssetPostServiceFilter,
 	}
 

--- a/products/xray/cli/post_service_id_operation.go
+++ b/products/xray/cli/post_service_id_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationServiceAssetPostServiceIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostServiceID",
-		Short: ``,
+		Short: `修改服务资产`,
 		RunE:  runOperationServiceAssetPostServiceID,
 	}
 

--- a/products/xray/cli/post_service_operation.go
+++ b/products/xray/cli/post_service_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationServiceAssetPostServiceCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostService",
-		Short: ``,
+		Short: `批量增加服务`,
 		RunE:  runOperationServiceAssetPostService,
 	}
 

--- a/products/xray/cli/post_ssh_key_create_operation.go
+++ b/products/xray/cli/post_ssh_key_create_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationBaselinePostSSHKeyCreateCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostSSHKeyCreate",
-		Short: ``,
+		Short: `创建SSH 认证私钥`,
 		RunE:  runOperationBaselinePostSSHKeyCreate,
 	}
 

--- a/products/xray/cli/post_ssh_key_filter_operation.go
+++ b/products/xray/cli/post_ssh_key_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationBaselinePostSSHKeyFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostSSHKeyFilter",
-		Short: ``,
+		Short: `按条件批量获取SSH 认证私钥`,
 		RunE:  runOperationBaselinePostSSHKeyFilter,
 	}
 

--- a/products/xray/cli/post_system_dns_engine_id_operation.go
+++ b/products/xray/cli/post_system_dns_engine_id_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationSystemInfoPostSystemDNSEngineIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostSystemDNSEngineID",
-		Short: ``,
+		Short: `设置引擎节点的 dns 配置`,
 		RunE:  runOperationSystemInfoPostSystemDNSEngineID,
 	}
 

--- a/products/xray/cli/post_system_hosts_engine_id_operation.go
+++ b/products/xray/cli/post_system_hosts_engine_id_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationSystemInfoPostSystemHostsEngineIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostSystemHostsEngineID",
-		Short: ``,
+		Short: `设置引擎节点的 hosts 配置`,
 		RunE:  runOperationSystemInfoPostSystemHostsEngineID,
 	}
 

--- a/products/xray/cli/post_system_info_services_operation.go
+++ b/products/xray/cli/post_system_info_services_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationSystemInfoPostSystemInfoServicesCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostSystemInfoServices",
-		Short: ``,
+		Short: `查询系统服务工作状态和负载信息`,
 		RunE:  runOperationSystemInfoPostSystemInfoServices,
 	}
 

--- a/products/xray/cli/post_system_license_operation.go
+++ b/products/xray/cli/post_system_license_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationSystemServicePostSystemLicenseCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostSystemLicense",
-		Short: ``,
+		Short: `上传许可证`,
 		RunE:  runOperationSystemServicePostSystemLicense,
 	}
 

--- a/products/xray/cli/post_upload_custompoc_operation.go
+++ b/products/xray/cli/post_upload_custompoc_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationCustomPocPostUploadCustompocCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostUploadCustompoc",
-		Short: ``,
+		Short: `创建自定义poc`,
 		RunE:  runOperationCustomPocPostUploadCustompoc,
 	}
 

--- a/products/xray/cli/post_upload_upgrade_package_operation.go
+++ b/products/xray/cli/post_upload_upgrade_package_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationSystemServicePostUploadUpgradePackageCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostUploadUpgradePackage",
-		Short: ``,
+		Short: `上传升级包`,
 		RunE:  runOperationSystemServicePostUploadUpgradePackage,
 	}
 

--- a/products/xray/cli/post_user_filter_operation.go
+++ b/products/xray/cli/post_user_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationUserPostUserFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostUserFilter",
-		Short: ``,
+		Short: `根据用户名或 remote_id 筛选用户。`,
 		RunE:  runOperationUserPostUserFilter,
 	}
 

--- a/products/xray/cli/post_user_operation.go
+++ b/products/xray/cli/post_user_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationUserPostUserCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostUser",
-		Short: ``,
+		Short: `创建用户`,
 		RunE:  runOperationUserPostUser,
 	}
 

--- a/products/xray/cli/post_user_token_refresh_operation.go
+++ b/products/xray/cli/post_user_token_refresh_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationUserPostUserTokenRefreshCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostUserTokenRefresh",
-		Short: ``,
+		Short: `刷新token(token值会变,有效期不会额外展期)`,
 		RunE:  runOperationUserPostUserTokenRefresh,
 	}
 

--- a/products/xray/cli/post_vuln_filter_operation.go
+++ b/products/xray/cli/post_vuln_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationVulnerabilityPostVulnFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostVulnFilter",
-		Short: ``,
+		Short: `按条件批量获取漏洞`,
 		RunE:  runOperationVulnerabilityPostVulnFilter,
 	}
 

--- a/products/xray/cli/post_vuln_id_operation.go
+++ b/products/xray/cli/post_vuln_id_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationVulnerabilityPostVulnIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostVulnID",
-		Short: ``,
+		Short: `修改漏洞资产`,
 		RunE:  runOperationVulnerabilityPostVulnID,
 	}
 

--- a/products/xray/cli/post_vuln_library_upgrade_operation.go
+++ b/products/xray/cli/post_vuln_library_upgrade_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationSystemServicePostVulnLibraryUpgradeCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostVulnLibraryUpgrade",
-		Short: ``,
+		Short: `漏洞库升级，请确保升级包校验通过`,
 		RunE:  runOperationSystemServicePostVulnLibraryUpgrade,
 	}
 

--- a/products/xray/cli/post_vuln_retest_operation.go
+++ b/products/xray/cli/post_vuln_retest_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationVulnerabilityPostVulnRetestCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostVulnRetest",
-		Short: ``,
+		Short: `复测漏洞资产`,
 		RunE:  runOperationVulnerabilityPostVulnRetest,
 	}
 

--- a/products/xray/cli/post_website_filter_simple_operation.go
+++ b/products/xray/cli/post_website_filter_simple_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationWebAssetPostWebsiteFilterSimpleCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostWebsiteFilterSimple",
-		Short: ``,
+		Short: `按条件批量获取精简的 Web 站点`,
 		RunE:  runOperationWebAssetPostWebsiteFilterSimple,
 	}
 

--- a/products/xray/cli/post_website_id_operation.go
+++ b/products/xray/cli/post_website_id_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationWebAssetPostWebsiteIDCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostWebsiteID",
-		Short: ``,
+		Short: `修改 Web 站点`,
 		RunE:  runOperationWebAssetPostWebsiteID,
 	}
 

--- a/products/xray/cli/post_website_operation.go
+++ b/products/xray/cli/post_website_operation.go
@@ -17,7 +17,7 @@ import (
 func makeOperationWebAssetPostWebsiteCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostWebsite",
-		Short: ``,
+		Short: `批量增加 Web 站点`,
 		RunE:  runOperationWebAssetPostWebsite,
 	}
 

--- a/products/xray/cli/post_whitelist_filter_operation.go
+++ b/products/xray/cli/post_whitelist_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationTaskConfigPostWhitelistFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostWhitelistFilter",
-		Short: ``,
+		Short: `获取全局白名单`,
 		RunE:  runOperationTaskConfigPostWhitelistFilter,
 	}
 

--- a/products/xray/cli/post_whitelist_update_operation.go
+++ b/products/xray/cli/post_whitelist_update_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationTaskConfigPostWhitelistUpdateCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostWhitelistUpdate",
-		Short: ``,
+		Short: `更新全局白名单`,
 		RunE:  runOperationTaskConfigPostWhitelistUpdate,
 	}
 

--- a/products/xray/cli/post_xprocess_filter_operation.go
+++ b/products/xray/cli/post_xprocess_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationXprocessPostXprocessFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostXprocessFilter",
-		Short: ``,
+		Short: `按条件批量获取 XProcess`,
 		RunE:  runOperationXprocessPostXprocessFilter,
 	}
 

--- a/products/xray/cli/post_xprocess_lite_filter_operation.go
+++ b/products/xray/cli/post_xprocess_lite_filter_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationXprocessLitePostXprocessLiteFilterCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostXprocessLiteFilter",
-		Short: ``,
+		Short: `按条件批量获取 XProcess(精简)`,
 		RunE:  runOperationXprocessLitePostXprocessLiteFilter,
 	}
 

--- a/products/xray/cli/post_xprocess_pause_operation.go
+++ b/products/xray/cli/post_xprocess_pause_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationXprocessPostXprocessPauseCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostXprocessPause",
-		Short: ``,
+		Short: `暂停任务实例`,
 		RunE:  runOperationXprocessPostXprocessPause,
 	}
 

--- a/products/xray/cli/post_xprocess_pause_stage_operation.go
+++ b/products/xray/cli/post_xprocess_pause_stage_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationXprocessPostXprocessPauseStageCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostXprocessPauseStage",
-		Short: ``,
+		Short: `暂停任务实例的某个阶段, 仅支持扫描策略为被动web(流量)的任务`,
 		RunE:  runOperationXprocessPostXprocessPauseStage,
 	}
 

--- a/products/xray/cli/post_xprocess_resume_operation.go
+++ b/products/xray/cli/post_xprocess_resume_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationXprocessPostXprocessResumeCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostXprocessResume",
-		Short: ``,
+		Short: `恢复任务实例`,
 		RunE:  runOperationXprocessPostXprocessResume,
 	}
 

--- a/products/xray/cli/post_xprocess_resume_stage_operation.go
+++ b/products/xray/cli/post_xprocess_resume_stage_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationXprocessPostXprocessResumeStageCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostXprocessResumeStage",
-		Short: ``,
+		Short: `恢复任务实例的某个阶段, 仅支持扫描策略为被动web(流量)的任务`,
 		RunE:  runOperationXprocessPostXprocessResumeStage,
 	}
 

--- a/products/xray/cli/post_xprocess_stop_operation.go
+++ b/products/xray/cli/post_xprocess_stop_operation.go
@@ -18,7 +18,7 @@ import (
 func makeOperationXprocessPostXprocessStopCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostXprocessStop",
-		Short: ``,
+		Short: `停止任务实例（结束任务的执行状态）`,
 		RunE:  runOperationXprocessPostXprocessStop,
 	}
 


### PR DESCRIPTION
- Add --help descriptions to all xray subcommands from swagger spec
- Add Short/Long descriptions to parent command groups
- Add top-level description for xray: 洞鉴(XRay) 风险评估系统
- Rename xray to 洞鉴(XRay) in README
- Remove completion and markdown commands (not API related)
- Update PostPlanCreateQuick with Chinese descriptions
- Update PostPlanExecute description
- Update README with full command paths and descriptions