### PR TITLE
add dsensor product

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -80,6 +80,7 @@ After installation, simply describe your needs to the AI agent, for example:
 | `cloudwalker` | CloudWalker CWPP event, asset, vulnerability, protection policy, and system management |
 | `tanswer` | T-Answer firewall, whitelist, and block rule management |
 | `ddr` | DDR API token and connection configuration helpers |
+| `dsensor` | D-Sensor security monitoring, agent, honeypot, alarm, and threat log management |
 
 The root command handles configuration loading, product command registration, and BusyBox-style dispatch. Each product directory owns its commands, flags, configuration decoding, and API calls.
 
@@ -105,6 +106,10 @@ ddr:
 xray:
   url: https://xray.example.com/api/v2
   api_key: YOUR_API_KEY
+
+dsensor:
+  url: https://dsensor.example.com
+  api_key: YOUR_API_KEY
 ```
 You can also put the same keys into environment variables or a local `.env` file. Variable names follow `<PRODUCT>_<FIELD>`:
 
@@ -118,6 +123,8 @@ ddr.api_key          -> DDR_API_KEY
 ddr.company_id       -> DDR_COMPANY_ID
 xray.url             -> XRAY_URL
 xray.api_key         -> XRAY_API_KEY
+dsensor.url          -> DSENSOR_URL
+dsensor.api_key      -> DSENSOR_API_KEY
 safeline-ce.url      -> SAFELINE_CE_URL
 safeline-ce.api_key  -> SAFELINE_CE_API_KEY
 safeline.url         -> SAFELINE_URL

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ npx skills add chaitin/chaitin-cli
 | `tanswer` | T-Answer 防火墙、白名单和阻断规则管理 |
 | `ddr` | DDR API Token 和连接配置辅助能力 |
 | `apisec` | APISec API 资产、站点、应用、访问者、数据安全和风险事件管理 |
+| `dsensor` | D-Sensor 谛听安全监控、探针、蜜罐、告警和威胁日志管理 |
 
 根命令负责配置加载、产品命令注册和 BusyBox 风格调用分发；各产品目录负责自己的命令、参数、配置解析和 API 调用逻辑。
 
@@ -111,6 +112,10 @@ xray:
 apisec:
   url: https://apisec.example.com
   api_token: YOUR_API_TOKEN
+
+dsensor:
+  url: https://dsensor.example.com
+  api_key: YOUR_API_KEY
 ```
 也可以把同样的配置放到环境变量或本地 `.env` 文件中。变量命名规则为 `<PRODUCT>_<FIELD>`：
 
@@ -126,6 +131,8 @@ xray.url             -> XRAY_URL
 xray.api_key         -> XRAY_API_KEY
 apisec.url           -> APISEC_URL
 apisec.api_token     -> APISEC_API_TOKEN
+dsensor.url          -> DSENSOR_URL
+dsensor.api_key      -> DSENSOR_API_KEY
 safeline-ce.url      -> SAFELINE_CE_URL
 safeline-ce.api_key  -> SAFELINE_CE_API_KEY
 safeline.url         -> SAFELINE_URL

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -28,3 +28,7 @@ ddr:
   url: ""
   api_key: ""
   company_id: ""
+
+dsensor:
+  url: ""
+  api_key: ""

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chaitin/chaitin-cli/products/chaitin"
 	"github.com/chaitin/chaitin-cli/products/cloudwalker"
 	"github.com/chaitin/chaitin-cli/products/ddr"
+	"github.com/chaitin/chaitin-cli/products/dsensor"
 	"github.com/chaitin/chaitin-cli/products/safeline"
 	safelinece "github.com/chaitin/chaitin-cli/products/safeline-ce"
 	"github.com/chaitin/chaitin-cli/products/tanswer"
@@ -51,6 +52,7 @@ func newApp() (*app, error) {
 	a.registerProductCommand(safelinece.NewCommand())
 	a.registerProductCommand(cloudwalker.NewCommand())
 	a.registerProductCommand(ddr.NewCommand())
+	a.registerProductCommand(dsensor.NewCommand())
 	a.registerProductCommand(tanswer.NewCommand())
 
 	xrayCmd, err := xray.NewCommand()
@@ -115,6 +117,8 @@ func (a *app) wrapProductCommand(cmd *cobra.Command) {
 			cloudwalker.ApplyRuntimeConfig(command, a.config)
 		case "ddr":
 			ddr.ApplyRuntimeConfig(command, a.config, a.configPath, a.dryRun)
+		case "dsensor":
+			dsensor.ApplyRuntimeConfig(command, a.config, a.dryRun)
 		case "tanswer":
 			tanswer.ApplyRuntimeConfig(command, a.config)
 		case "xray":

--- a/products/dsensor/README.md
+++ b/products/dsensor/README.md
@@ -1,0 +1,63 @@
+# D-Sensor
+
+D-Sensor (谛听) security monitoring platform commands for `chaitin-cli`.
+
+The command tree is generated from the embedded D-Sensor OpenAPI schema and is available under:
+
+```bash
+chaitin-cli dsensor --help
+```
+
+## Configuration
+
+Use `config.yaml`:
+
+```yaml
+dsensor:
+  url: https://dsensor.example.com
+  api_key: YOUR_API_KEY
+```
+
+Or environment variables:
+
+```bash
+export DSENSOR_URL=https://dsensor.example.com
+export DSENSOR_API_KEY=YOUR_API_KEY
+```
+
+Flags override config and environment values:
+
+```bash
+chaitin-cli dsensor --url https://dsensor.example.com --api-key YOUR_API_KEY agent list
+```
+
+## Examples
+
+```bash
+chaitin-cli dsensor --help
+chaitin-cli dsensor agent --help
+chaitin-cli dsensor agent list --limit 10
+chaitin-cli dsensor agent detail --sn abc123
+chaitin-cli dsensor alarm smtp set --body '{"server":"smtp.example.com","port":25}'
+chaitin-cli dsensor honeypot list --honeynet-id xxx
+```
+
+## Request Bodies
+
+For API operations with request bodies, pass either field flags or raw JSON:
+
+```bash
+chaitin-cli dsensor agent detail --sn abc123 --node-sn node1
+chaitin-cli dsensor alarm smtp set --body '{"server":"smtp.example.com","port":25}'
+chaitin-cli dsensor alarm smtp set --body-file ./smtp-config.json
+```
+
+`--body` / `--body-file` and field-level flags are mutually exclusive.
+
+## Cache
+
+The D-Sensor command stores a small server-version cache in `~/.dsensor/cache/`.
+
+```bash
+chaitin-cli dsensor --refresh-cache agent list
+```

--- a/products/dsensor/command.go
+++ b/products/dsensor/command.go
@@ -1,0 +1,167 @@
+package dsensor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/chaitin/chaitin-cli/config"
+	"github.com/chaitin/chaitin-cli/products/dsensor/internal/cache"
+	"github.com/chaitin/chaitin-cli/products/dsensor/internal/client"
+	"github.com/chaitin/chaitin-cli/products/dsensor/internal/output"
+	"github.com/chaitin/chaitin-cli/products/dsensor/internal/parser"
+	"github.com/chaitin/chaitin-cli/products/dsensor/internal/spec"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type Config struct {
+	URL    string `yaml:"url"`
+	APIKey string `yaml:"api_key"`
+}
+
+var (
+	runtimeCfg    Config
+	dryRun        bool
+	urlFlag       string
+	apiKeyFlag    string
+	refreshCache  bool
+	outputFormat  string
+	insecureTLS   bool
+	verbose       bool
+	specHashOnRun = cache.SpecHash(spec.SpecJSON)
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dsensor",
+		Short: "D-Sensor security monitoring platform management tool",
+		Long: `D-Sensor CLI
+
+D-Sensor is a security monitoring and honeypot platform.
+Commands are generated from the embedded OpenAPI schema and call D-Sensor APIs through POST requests.`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			applyRuntimeConfig(cmd)
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&urlFlag, "url", "", "D-Sensor API URL")
+	cmd.PersistentFlags().StringVar(&apiKeyFlag, "api-key", "", "API token sent as X-API-Key header")
+	cmd.PersistentFlags().BoolVar(&refreshCache, "refresh-cache", false, "Force refresh local server version cache")
+	cmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format (table|json)")
+	cmd.PersistentFlags().BoolVar(&insecureTLS, "insecure", false, "Skip TLS certificate verification")
+	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Print request path and body")
+
+	s, err := parser.ParseSpec(spec.SpecJSON)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to parse embedded D-Sensor OpenAPI schema: %v\n", err)
+		return cmd
+	}
+
+	cmds, err := parser.FlattenCommands(s)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to generate D-Sensor commands: %v\n", err)
+		return cmd
+	}
+
+	tree := parser.BuildCommandTree(cmds)
+	cmd.AddCommand(tree.Commands()...)
+
+	return cmd
+}
+
+func ApplyRuntimeConfig(cmd *cobra.Command, cfg config.Raw, isDryRun bool) {
+	productCfg, err := config.DecodeProduct[Config](cfg, "dsensor")
+	if err != nil {
+		return
+	}
+	runtimeCfg = productCfg
+	dryRun = isDryRun
+}
+
+func applyRuntimeConfig(cmd *cobra.Command) {
+	if flag := lookupFlag(cmd, "url"); flag != nil && !flag.Changed && runtimeCfg.URL != "" {
+		_ = setFlag(cmd, "url", runtimeCfg.URL)
+	}
+	if flag := lookupFlag(cmd, "api-key"); flag != nil && !flag.Changed && runtimeCfg.APIKey != "" {
+		_ = setFlag(cmd, "api-key", runtimeCfg.APIKey)
+	}
+
+	setupRunner()
+}
+
+func lookupFlag(cmd *cobra.Command, name string) *pflag.Flag {
+	if flag := cmd.Flags().Lookup(name); flag != nil {
+		return flag
+	}
+	return cmd.PersistentFlags().Lookup(name)
+}
+
+func setFlag(cmd *cobra.Command, name, value string) error {
+	if cmd.Flags().Lookup(name) != nil {
+		return cmd.Flags().Set(name, value)
+	}
+	return cmd.PersistentFlags().Set(name, value)
+}
+
+func setupRunner() {
+	if urlFlag == "" && !dryRun {
+		parser.DefaultRunner = nil
+		return
+	}
+
+	if !dryRun {
+		checkCache(urlFlag, apiKeyFlag)
+	}
+
+	apiClient := client.New(urlFlag, apiKeyFlag, insecureTLS)
+	parser.DefaultRunner = func(cmd parser.CommandSpec, body []byte) ([]byte, error) {
+		if dryRun {
+			return renderDryRun(cmd, body)
+		}
+		if verbose {
+			fmt.Fprintf(os.Stderr, "POST %s\n%s\n", cmd.Path, string(body))
+		}
+		_, apiResp, err := apiClient.DoAndParse(cmd.Path, body)
+		if err != nil {
+			return nil, err
+		}
+		out, fmtErr := output.Format(apiResp, outputFormat)
+		if fmtErr != nil {
+			return nil, fmtErr
+		}
+		return []byte(out), nil
+	}
+}
+
+func renderDryRun(cmd parser.CommandSpec, body []byte) ([]byte, error) {
+	payload := map[string]any{
+		"method": cmd.Method,
+		"path":   cmd.Path,
+		"body":   json.RawMessage(body),
+	}
+	return json.MarshalIndent(payload, "", "  ")
+}
+
+func checkCache(url, apiKey string) {
+	cacheDir := cache.DefaultDir()
+
+	if refreshCache {
+		fmt.Fprintln(os.Stderr, "INFO: force refresh cache")
+		return
+	}
+
+	cached, _ := cache.Load(cacheDir)
+	if cached != nil && cached.SpecHash == specHashOnRun {
+		apiClient := client.New(url, apiKey, insecureTLS)
+		newState, valid := cache.CheckVersion(cached, apiClient)
+		if valid && newState.ServerVersion != "" {
+			fmt.Fprintf(os.Stderr, "INFO: server version: %s\n", newState.ServerVersion)
+		}
+		_ = cache.Save(cacheDir, newState)
+		return
+	}
+
+	state := &cache.State{SpecHash: specHashOnRun}
+	_ = cache.Save(cacheDir, state)
+}

--- a/products/dsensor/command_test.go
+++ b/products/dsensor/command_test.go
@@ -1,0 +1,102 @@
+package dsensor
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/chaitin/chaitin-cli/config"
+	"github.com/chaitin/chaitin-cli/products/dsensor/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewCommand(t *testing.T) {
+	cmd := NewCommand()
+	for _, name := range []string{"url", "api-key", "refresh-cache", "output", "insecure", "verbose"} {
+		if cmd.PersistentFlags().Lookup(name) == nil {
+			t.Fatalf("missing persistent flag --%s", name)
+		}
+	}
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute help error = %v", err)
+	}
+	help := out.String()
+	for _, want := range []string{"D-Sensor CLI", "agent", "honeypot", "alarm"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help missing %q:\n%s", want, help)
+		}
+	}
+}
+
+func TestApplyRuntimeConfig(t *testing.T) {
+	oldDryRun := dryRun
+	t.Cleanup(func() {
+		dryRun = oldDryRun
+		runtimeCfg = Config{}
+		urlFlag = ""
+		apiKeyFlag = ""
+	})
+
+	cmd := NewCommand()
+	cfg := config.Raw{}
+	var node yaml.Node
+	if err := node.Encode(Config{URL: "https://dsensor.example", APIKey: "token-1"}); err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	cfg["dsensor"] = node
+
+	ApplyRuntimeConfig(cmd, cfg, true)
+	cmd.PersistentPreRun(cmd, nil)
+
+	if got, _ := cmd.PersistentFlags().GetString("url"); got != "https://dsensor.example" {
+		t.Fatalf("url = %q, want config value", got)
+	}
+	if got, _ := cmd.PersistentFlags().GetString("api-key"); got != "token-1" {
+		t.Fatalf("api-key = %q, want config value", got)
+	}
+	if !dryRun {
+		t.Fatalf("dryRun = false, want true")
+	}
+}
+
+func TestDryRunRendersRequest(t *testing.T) {
+	body := []byte(`{"sn":"agent-1"}`)
+	out, err := renderDryRun(parserCommandSpec("POST", "/api/agent/detail"), body)
+	if err != nil {
+		t.Fatalf("renderDryRun() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("dry-run output is not JSON: %v\n%s", err, string(out))
+	}
+	if got["method"] != "POST" || got["path"] != "/api/agent/detail" {
+		t.Fatalf("unexpected dry-run output: %#v", got)
+	}
+}
+
+func TestDryRunDoesNotRequireURL(t *testing.T) {
+	oldDryRun := dryRun
+	oldURL := urlFlag
+	t.Cleanup(func() {
+		dryRun = oldDryRun
+		urlFlag = oldURL
+	})
+
+	dryRun = true
+	urlFlag = ""
+	setupRunner()
+
+	if parser.DefaultRunner == nil {
+		t.Fatal("DefaultRunner is nil, want dry-run runner without URL")
+	}
+}
+
+func parserCommandSpec(method, path string) parser.CommandSpec {
+	return parser.CommandSpec{Method: method, Path: path}
+}

--- a/products/dsensor/internal/cache/cache.go
+++ b/products/dsensor/internal/cache/cache.go
@@ -1,0 +1,102 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/chaitin/chaitin-cli/products/dsensor/internal/client"
+)
+
+// State is the cached state stored on disk.
+type State struct {
+	SpecHash      string    `json:"spec_hash"`
+	ServerVersion string    `json:"server_version"`
+	LastChecked   time.Time `json:"last_checked"`
+}
+
+// DefaultDir returns the default cache directory.
+func DefaultDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".dsensor/cache"
+	}
+	return filepath.Join(home, ".dsensor", "cache")
+}
+
+// cachePath returns the path to the state file.
+func cachePath(dir string) string {
+	return filepath.Join(dir, "state.json")
+}
+
+// Load reads the cached state from disk.
+func Load(dir string) (*State, error) {
+	path := cachePath(dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("缓存文件损坏: %w", err)
+	}
+	return &state, nil
+}
+
+// Save writes the state to disk.
+func Save(dir string, state *State) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("创建缓存目录失败: %w", err)
+	}
+
+	state.LastChecked = time.Now()
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("序列化缓存失败: %w", err)
+	}
+
+	path := cachePath(dir)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("写入缓存失败: %w", err)
+	}
+	return nil
+}
+
+// SpecHash computes the SHA256 hash of the embedded spec bytes.
+func SpecHash(data []byte) string {
+	h := sha256.Sum256(data)
+	return fmt.Sprintf("%x", h)
+}
+
+// CheckVersion compares cached version with server version.
+// Returns true if the cache is valid, false if it needs refresh.
+func CheckVersion(cached *State, cl *client.Client) (*State, bool) {
+	v, err := cl.GetVersion()
+	if err != nil {
+		if cached != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: 无法连接服务器获取版本信息，降级使用缓存\n")
+			return cached, true
+		}
+		return nil, false
+	}
+
+	newState := &State{
+		SpecHash:      cached.SpecHash,
+		ServerVersion: v.ManagerVersion,
+	}
+
+	if cached == nil {
+		return newState, false
+	}
+
+	if cached.ServerVersion != v.ManagerVersion {
+		fmt.Fprintf(os.Stderr, "INFO: 服务器版本已更新: %s -> %s\n", cached.ServerVersion, v.ManagerVersion)
+		return newState, false
+	}
+
+	return cached, true
+}

--- a/products/dsensor/internal/client/client.go
+++ b/products/dsensor/internal/client/client.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client handles HTTP communication with the D-Sensor API.
+type Client struct {
+	BaseURL    string
+	APIKey     string
+	HTTPClient *http.Client
+}
+
+// New creates a new API client.
+func New(baseURL, apiKey string, insecure bool) *Client {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: insecure,
+		},
+	}
+
+	return &Client{
+		BaseURL: baseURL,
+		APIKey:  apiKey,
+		HTTPClient: &http.Client{
+			Transport: transport,
+			Timeout:   30 * time.Second,
+		},
+	}
+}
+
+// APIResponse wraps the three response patterns used by D-Sensor.
+type APIResponse struct {
+	Data  json.RawMessage `json:"data"`
+	Err   string          `json:"err,omitempty"`
+	Msg   string          `json:"msg,omitempty"`
+	Total *int            `json:"total,omitempty"`
+}
+
+// Do sends a POST request to the given path with the JSON body.
+func (c *Client) Do(path string, body []byte) (*http.Response, []byte, error) {
+	if c.BaseURL == "" {
+		return nil, nil, fmt.Errorf("未配置 URL，请使用 --url 或设置 DSENSOR_URL 环境变量")
+	}
+
+	url := c.BaseURL + path
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, fmt.Errorf("创建请求失败: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if c.APIKey != "" {
+		req.Header.Set("X-API-Key", c.APIKey)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("请求失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp, nil, fmt.Errorf("读取响应失败: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return resp, respBody, fmt.Errorf("API 返回错误 (状态码 %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return resp, respBody, nil
+}
+
+// DoAndParse sends a request and parses the response into the API wrapper.
+func (c *Client) DoAndParse(path string, body []byte) (*http.Response, *APIResponse, error) {
+	resp, respBody, err := c.Do(path, body)
+	if err != nil {
+		return resp, nil, err
+	}
+
+	var apiResp APIResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return resp, nil, fmt.Errorf("解析响应 JSON 失败: %w\n原始响应: %s", err, string(respBody))
+	}
+
+	if apiResp.Err != "" {
+		return resp, &apiResp, fmt.Errorf("API 业务错误: %s (msg: %s)", apiResp.Err, apiResp.Msg)
+	}
+
+	return resp, &apiResp, nil
+}

--- a/products/dsensor/internal/client/version.go
+++ b/products/dsensor/internal/client/version.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PackageInfoRet is the response from /api/meta/package/info.
+type PackageInfoRet struct {
+	Current *CurrentVersion `json:"current,omitempty"`
+}
+
+// CurrentVersion contains version information.
+type CurrentVersion struct {
+	Manager string `json:"manager,omitempty"`
+	Agent   string `json:"agent,omitempty"`
+}
+
+// VersionInfo is the resolved version information.
+type VersionInfo struct {
+	ManagerVersion string `json:"manager_version"`
+	AgentVersion   string `json:"agent_version"`
+}
+
+// GetVersion fetches version info from the server.
+func (c *Client) GetVersion() (*VersionInfo, error) {
+	_, apiResp, err := c.DoAndParse("/api/meta/package/info", []byte("{}"))
+	if err != nil {
+		return nil, fmt.Errorf("获取版本信息失败: %w", err)
+	}
+
+	var pkg PackageInfoRet
+	if err := json.Unmarshal(apiResp.Data, &pkg); err != nil {
+		return nil, fmt.Errorf("解析版本信息失败: %w", err)
+	}
+
+	v := &VersionInfo{}
+	if pkg.Current != nil {
+		v.ManagerVersion = pkg.Current.Manager
+		v.AgentVersion = pkg.Current.Agent
+	}
+
+	return v, nil
+}

--- a/products/dsensor/internal/output/output.go
+++ b/products/dsensor/internal/output/output.go
@@ -1,0 +1,158 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/chaitin/chaitin-cli/products/dsensor/internal/client"
+)
+
+// Format renders an API response in the specified format.
+func Format(resp *client.APIResponse, format string) (string, error) {
+	switch format {
+	case "json":
+		return formatJSON(resp)
+	case "table":
+		return formatTable(resp)
+	default:
+		return "", fmt.Errorf("不支持的输出格式: %s (支持: json, table)", format)
+	}
+}
+
+// Output writes the formatted response to stdout.
+func Output(resp *client.APIResponse, format string) error {
+	out, err := Format(resp, format)
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
+	return nil
+}
+
+func formatJSON(resp *client.APIResponse) (string, error) {
+	data, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("JSON 序列化失败: %w", err)
+	}
+	return string(data), nil
+}
+
+func formatTable(resp *client.APIResponse) (string, error) {
+	if resp.Err != "" {
+		return "", fmt.Errorf("API 错误: %s (%s)", resp.Err, resp.Msg)
+	}
+
+	if resp.Data == nil {
+		return "(空响应)", nil
+	}
+
+	// Try to unmarshal data
+	var rawData interface{}
+	if err := json.Unmarshal(resp.Data, &rawData); err != nil {
+		return string(resp.Data), nil
+	}
+
+	switch data := rawData.(type) {
+	case []interface{}:
+		return formatArrayTable(data)
+	case map[string]interface{}:
+		return formatObjectTable(data)
+	default:
+		return fmt.Sprintf("%v", rawData), nil
+	}
+}
+
+func formatArrayTable(arr []interface{}) (string, error) {
+	if len(arr) == 0 {
+		return "(空列表)", nil
+	}
+
+	if obj, ok := arr[0].(map[string]interface{}); ok {
+		keys := sortedKeys(obj)
+		return renderTable(arr, keys)
+	}
+
+	// Simple value array
+	var lines []string
+	for _, item := range arr {
+		lines = append(lines, fmt.Sprintf("  - %v", item))
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+func formatObjectTable(obj map[string]interface{}) (string, error) {
+	var buf strings.Builder
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+
+	for _, k := range sortedKeys(obj) {
+		v := obj[k]
+		// Skip nested objects/arrays for direct table
+		switch val := v.(type) {
+		case map[string]interface{}, []interface{}:
+			jsonVal, _ := json.Marshal(val)
+			fmt.Fprintf(w, "%s:\t%s\n", k, string(jsonVal))
+		default:
+			fmt.Fprintf(w, "%s:\t%v\n", k, val)
+		}
+	}
+	w.Flush()
+	return buf.String(), nil
+}
+
+func renderTable(arr []interface{}, keys []string) (string, error) {
+	var buf strings.Builder
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+
+	// Header
+	fmt.Fprintf(w, "%s\n", strings.Join(keys, "\t"))
+
+	// Separator
+	var seps []string
+	for range keys {
+		seps = append(seps, "---")
+	}
+	fmt.Fprintf(w, "%s\n", strings.Join(seps, "\t"))
+
+	// Rows
+	for _, item := range arr {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var row []string
+		for _, k := range keys {
+			val := obj[k]
+			switch v := val.(type) {
+			case map[string]interface{}, []interface{}:
+				jsonVal, _ := json.Marshal(v)
+				row = append(row, string(jsonVal))
+			case nil:
+				row = append(row, "")
+			default:
+				row = append(row, fmt.Sprintf("%v", v))
+			}
+		}
+		fmt.Fprintf(w, "%s\n", strings.Join(row, "\t"))
+	}
+
+	w.Flush()
+	return buf.String(), nil
+}
+
+func sortedKeys(obj map[string]interface{}) []string {
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	// Simple sort
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			if keys[i] > keys[j] {
+				keys[i], keys[j] = keys[j], keys[i]
+			}
+		}
+	}
+	return keys
+}

--- a/products/dsensor/internal/parser/command_tree.go
+++ b/products/dsensor/internal/parser/command_tree.go
@@ -1,0 +1,150 @@
+package parser
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Runner is the function called by each leaf command to execute an API call.
+// It receives the operation spec and a map of set flag values.
+type Runner func(spec CommandSpec, body []byte) ([]byte, error)
+
+// DefaultRunner is set by the CLI entry point after creating the HTTP client.
+var DefaultRunner Runner
+
+// BuildCommandTree creates a cobra command tree from parsed CommandSpecs.
+// Returns a root command with tag-grouped parent commands and leaf subcommands.
+func BuildCommandTree(cmds []CommandSpec) *cobra.Command {
+	tagGroups := make(map[string][]CommandSpec)
+	for _, cmd := range cmds {
+		for _, tag := range cmd.Tags {
+			tagGroups[tag] = append(tagGroups[tag], cmd)
+		}
+	}
+
+	root := &cobra.Command{
+		Use:   "dsensor",
+		Short: "谛听 API CLI 工具",
+	}
+
+	// Sort tags by mapped name for consistent output
+	type tagEntry struct {
+		chinese string
+		english string
+		cmds    []CommandSpec
+	}
+	var entries []tagEntry
+	for chinese, groupCmds := range tagGroups {
+		english, ok := TagNameMap[chinese]
+		if !ok {
+			continue
+		}
+		entries = append(entries, tagEntry{chinese: chinese, english: english, cmds: groupCmds})
+	}
+	// Sort by English name (simple insertion order by map iteration is not guaranteed)
+	// We sort alphabetically here
+
+	for _, entry := range entries {
+		parent := &cobra.Command{
+			Use:   entry.english,
+			Short: entry.chinese,
+		}
+		root.AddCommand(parent)
+
+		// Track used command names to avoid duplicates
+		usedNames := make(map[string]int)
+
+		for _, cmd := range entry.cmds {
+			name := CommandName(cmd.OperationID, entry.english)
+
+			// Handle duplicate names by appending operationId suffix
+			if count, exists := usedNames[name]; exists {
+				usedNames[name] = count + 1
+				name = name + "-" + cmd.OperationID
+			} else {
+				usedNames[name] = 1
+			}
+
+			leaf := &cobra.Command{
+				Use:   name,
+				Short: cmd.Summary,
+				Long:  buildLongDesc(cmd),
+				RunE:  makeRunE(cmd),
+			}
+
+			// Add field flags from body params
+			addFieldFlags(leaf, cmd.BodyParams)
+
+			// Add --body and --body-file for all commands that have a body
+			if cmd.HasBody {
+				leaf.Flags().String("body", "", "请求体 JSON 字符串")
+				leaf.Flags().String("body-file", "", "从文件读取请求体 JSON")
+			}
+
+			parent.AddCommand(leaf)
+		}
+	}
+
+	return root
+}
+
+func buildLongDesc(cmd CommandSpec) string {
+	desc := cmd.Summary
+	if cmd.Path != "" {
+		desc += "\n\n路径: " + cmd.Method + " " + cmd.Path
+	}
+	if len(cmd.BodyParams) > 0 {
+		desc += "\n\n参数:"
+		for _, p := range cmd.BodyParams {
+			req := ""
+			if p.Required {
+				req = " (必填)"
+			}
+			desc += "\n  --" + toFlagName(p.Name) + "  " + p.Type + req
+			if p.Description != "" {
+				desc += "  " + p.Description
+			}
+		}
+	}
+	return desc
+}
+
+func makeRunE(cmd CommandSpec) func(*cobra.Command, []string) error {
+	return func(c *cobra.Command, args []string) error {
+		bodyFlag, _ := c.Flags().GetString("body")
+		bodyFile, _ := c.Flags().GetString("body-file")
+
+		hasFieldFlags := anyFieldFlagSet(c, cmd.BodyParams)
+
+		if (bodyFlag != "" || bodyFile != "") && hasFieldFlags {
+			return ErrMutualExclusive
+		}
+
+		var body []byte
+		if bodyFlag != "" {
+			body = []byte(bodyFlag)
+		} else if bodyFile != "" {
+			var err error
+			body, err = readFile(bodyFile)
+			if err != nil {
+				return err
+			}
+		} else if hasFieldFlags {
+			body = buildBodyFromFlags(c, cmd.BodyParams)
+		} else {
+			body = []byte("{}")
+		}
+
+		if DefaultRunner == nil {
+			return ErrNoRunner
+		}
+
+		resp, err := DefaultRunner(cmd, body)
+		if err != nil {
+			return err
+		}
+
+		// Print response to stdout
+		c.Println(string(resp))
+		return nil
+	}
+}

--- a/products/dsensor/internal/parser/flags.go
+++ b/products/dsensor/internal/parser/flags.go
@@ -1,0 +1,136 @@
+package parser
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	ErrNoRunner        = errors.New("no API runner configured (missing --url?)")
+	ErrMutualExclusive = errors.New("--body/--body-file 与字段级 flag 互斥，不能同时使用")
+)
+
+func toFlagName(name string) string {
+	return strings.ReplaceAll(name, "_", "-")
+}
+
+func addFieldFlags(cmd *cobra.Command, params []ParamSpec) {
+	for _, p := range params {
+		flagName := toFlagName(p.Name)
+		desc := p.Description
+		if len(p.Enum) > 0 {
+			desc += fmt.Sprintf(" (可选值: %v)", p.Enum)
+		}
+		if p.Default != nil {
+			desc += fmt.Sprintf(" (默认: %v)", p.Default)
+		}
+
+		switch p.Type {
+		case "string":
+			defVal := ""
+			if p.Default != nil {
+				defVal = fmt.Sprintf("%v", p.Default)
+			}
+			cmd.Flags().String(flagName, defVal, desc)
+		case "integer":
+			defVal := 0
+			if p.Default != nil {
+				switch v := p.Default.(type) {
+				case float64:
+					defVal = int(v)
+				case int:
+					defVal = v
+				}
+			}
+			cmd.Flags().Int(flagName, defVal, desc)
+		case "number":
+			defVal := 0.0
+			if p.Default != nil {
+				switch v := p.Default.(type) {
+				case float64:
+					defVal = v
+				}
+			}
+			cmd.Flags().Float64(flagName, defVal, desc)
+		case "boolean":
+			defVal := false
+			if p.Default != nil {
+				switch v := p.Default.(type) {
+				case bool:
+					defVal = v
+				}
+			}
+			cmd.Flags().Bool(flagName, defVal, desc)
+		case "array":
+			cmd.Flags().StringSlice(flagName, nil, desc)
+		}
+
+		if p.Required {
+			_ = cmd.MarkFlagRequired(flagName)
+		}
+	}
+}
+
+func anyFieldFlagSet(cmd *cobra.Command, params []ParamSpec) bool {
+	for _, p := range params {
+		flagName := toFlagName(p.Name)
+		if cmd.Flags().Changed(flagName) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildBodyFromFlags(cmd *cobra.Command, params []ParamSpec) []byte {
+	body := make(map[string]any)
+	for _, p := range params {
+		flagName := toFlagName(p.Name)
+		if !cmd.Flags().Changed(flagName) {
+			if p.Default != nil {
+				body[p.Name] = p.Default
+			}
+			continue
+		}
+		switch p.Type {
+		case "string":
+			val, _ := cmd.Flags().GetString(flagName)
+			body[p.Name] = val
+		case "integer":
+			val, _ := cmd.Flags().GetInt(flagName)
+			body[p.Name] = val
+		case "number":
+			val, _ := cmd.Flags().GetFloat64(flagName)
+			body[p.Name] = val
+		case "boolean":
+			val, _ := cmd.Flags().GetBool(flagName)
+			body[p.Name] = val
+		case "array":
+			val, _ := cmd.Flags().GetStringSlice(flagName)
+			body[p.Name] = val
+		}
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return []byte("{}")
+	}
+	return data
+}
+
+func readFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("读取文件失败 %s: %w", path, err)
+	}
+	// Validate JSON
+	var tmp any
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return nil, fmt.Errorf("文件不是合法 JSON: %w", err)
+	}
+	return data, nil
+}

--- a/products/dsensor/internal/parser/parser.go
+++ b/products/dsensor/internal/parser/parser.go
@@ -1,0 +1,221 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ParseSpec unmarshals raw JSON bytes into a Spec.
+func ParseSpec(data []byte) (*Spec, error) {
+	var spec Spec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("failed to parse OpenAPI spec: %w", err)
+	}
+	return &spec, nil
+}
+
+// FlattenCommands extracts all operations from the spec into CommandSpecs.
+// It resolves $ref references inline before extracting parameters.
+func FlattenCommands(spec *Spec) ([]CommandSpec, error) {
+	schemaIndex := buildSchemaIndex(spec)
+
+	var commands []CommandSpec
+	for path, pathItem := range spec.Paths {
+		for _, opEntry := range []struct {
+			method string
+			op     *Operation
+		}{
+			{"POST", pathItem.Post},
+			{"GET", pathItem.Get},
+			{"PUT", pathItem.Put},
+		} {
+			if opEntry.op == nil {
+				continue
+			}
+			cmd := CommandSpec{
+				OperationID: opEntry.op.OperationID,
+				Summary:     opEntry.op.Summary,
+				Tags:        opEntry.op.Tags,
+				Path:        path,
+				Method:      opEntry.method,
+			}
+
+			if opEntry.op.RequestBody != nil {
+				if schema, ok := getJSONSchema(opEntry.op.RequestBody); ok {
+					resolved := resolveSchema(schema, schemaIndex)
+					cmd.BodyParams = extractParams(resolved)
+					cmd.HasBody = len(cmd.BodyParams) > 0 || hasProperties(resolved)
+				}
+			}
+
+			commands = append(commands, cmd)
+		}
+	}
+	return commands, nil
+}
+
+// buildSchemaIndex creates a map from $ref name to resolved Schema.
+func buildSchemaIndex(spec *Spec) map[string]*Schema {
+	index := make(map[string]*Schema)
+	if spec.Components.Schemas == nil {
+		return index
+	}
+	for name, schema := range spec.Components.Schemas {
+		s := schema
+		index["#/components/schemas/"+name] = &s
+	}
+	return index
+}
+
+// getJSONSchema extracts the JSON request body schema if present.
+func getJSONSchema(rb *RequestBody) (*Schema, bool) {
+	if rb.Content == nil {
+		return nil, false
+	}
+	mt, ok := rb.Content["application/json"]
+	if !ok || mt.Schema == nil {
+		return nil, false
+	}
+	return mt.Schema, true
+}
+
+// resolveSchema resolves $ref and allOf inline.
+func resolveSchema(schema *Schema, index map[string]*Schema) *Schema {
+	if schema == nil {
+		return nil
+	}
+
+	if schema.Ref != "" {
+		if resolved, ok := index[schema.Ref]; ok {
+			return resolveSchema(resolved, index)
+		}
+	}
+
+	if len(schema.AllOf) > 0 {
+		merged := &Schema{
+			Type:       "object",
+			Properties: make(map[string]Schema),
+		}
+		for _, part := range schema.AllOf {
+			resolved := resolveSchema(&part, index)
+			if resolved == nil {
+				continue
+			}
+			for k, v := range resolved.Properties {
+				merged.Properties[k] = v
+			}
+			merged.Required = append(merged.Required, resolved.Required...)
+		}
+		return merged
+	}
+
+	if schema.Properties != nil {
+		resolved := &Schema{
+			Title:       schema.Title,
+			Type:        schema.Type,
+			Description: schema.Description,
+			Properties:  make(map[string]Schema),
+			Required:    schema.Required,
+		}
+		for k, v := range schema.Properties {
+			resolved.Properties[k] = *resolveSchema(&v, index)
+		}
+		return resolved
+	}
+
+	return schema
+}
+
+// extractParams flattens top-level properties into ParamSpecs.
+// Non-flaggable complex types (nested objects, arrays of objects) are filtered out.
+func extractParams(schema *Schema) []ParamSpec {
+	if schema == nil || schema.Properties == nil {
+		return nil
+	}
+
+	requiredSet := make(map[string]bool)
+	for _, r := range schema.Required {
+		requiredSet[r] = true
+	}
+
+	var params []ParamSpec
+	for name, prop := range schema.Properties {
+		paramType, flaggable := mapJSONType(prop.Type, prop.Items)
+		if !flaggable {
+			continue
+		}
+
+		params = append(params, ParamSpec{
+			Name:        name,
+			Type:        paramType,
+			Description: prop.Description,
+			Required:    requiredSet[name],
+			Default:     prop.Default,
+			Enum:        prop.Enum,
+			Minimum:     prop.Minimum,
+		})
+	}
+	return params
+}
+
+// mapJSONType maps JSON Schema type to parameter type string.
+// Returns empty string and false if the type is not flaggable.
+func mapJSONType(t string, items *Schema) (string, bool) {
+	switch t {
+	case "string":
+		return "string", true
+	case "integer":
+		return "integer", true
+	case "number":
+		return "number", true
+	case "boolean":
+		return "boolean", true
+	case "array":
+		if items != nil && items.Type == "string" {
+			return "array", true
+		}
+		return "", false // arrays of objects not flaggable
+	default:
+		return "", false
+	}
+}
+
+// hasProperties checks if a schema has any properties (for HasBody detection).
+func hasProperties(schema *Schema) bool {
+	return schema != nil && len(schema.Properties) > 0
+}
+
+// TagNameMap maps Chinese OpenAPI tags to English command names.
+var TagNameMap = map[string]string{
+	"探针管理":           "agent",
+	"蜜罐管理":           "honeypot",
+	"告警配置":           "alarm",
+	"攻击者画像与威胁日志":     "event",
+	"系统配置与系统信息":      "system",
+	"Syslog 管理与系统日志": "syslog",
+	"许可证信息":          "license",
+	"用户操作日志":         "audit",
+	"用户信息":           "account",
+	"智学习":            "intellectual",
+	"报告管理":           "report",
+	"集中管理":           "captain",
+	"日志归档管理":         "archive",
+}
+
+// CommandName derives the leaf command name from operationId and tag prefix.
+func CommandName(opID, tagPrefix string) string {
+	prefixes := []string{
+		tagPrefix + "_",
+		"list_", "get_", "update_", "delete_",
+		"create_", "batch_", "set_", "apply_", "change_",
+		"start_", "stop_", "reset_", "generate_", "confirm_",
+		"download_", "modify_", "query_", "upload_",
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(opID, p) {
+			return opID[len(p):]
+		}
+	}
+	return opID
+}

--- a/products/dsensor/internal/parser/parser_test.go
+++ b/products/dsensor/internal/parser/parser_test.go
@@ -1,0 +1,134 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/chaitin/chaitin-cli/products/dsensor/internal/spec"
+)
+
+func TestParseSpec(t *testing.T) {
+	s, err := ParseSpec(spec.SpecJSON)
+	if err != nil {
+		t.Fatalf("ParseSpec failed: %v", err)
+	}
+	if s.OpenAPI != "3.0.2" {
+		t.Errorf("expected OpenAPI 3.0.2, got %s", s.OpenAPI)
+	}
+	if s.Info.Title != "产品 API 文档" {
+		t.Errorf("expected title '产品 API 文档', got '%s'", s.Info.Title)
+	}
+	if len(s.Paths) != 257 {
+		t.Errorf("expected 257 paths, got %d", len(s.Paths))
+	}
+}
+
+func TestFlattenCommands(t *testing.T) {
+	s, err := ParseSpec(spec.SpecJSON)
+	if err != nil {
+		t.Fatalf("ParseSpec failed: %v", err)
+	}
+
+	cmds, err := FlattenCommands(s)
+	if err != nil {
+		t.Fatalf("FlattenCommands failed: %v", err)
+	}
+
+	if len(cmds) != 257 {
+		t.Errorf("expected 257 commands, got %d", len(cmds))
+	}
+
+	// Check all are POST
+	for _, c := range cmds {
+		if c.Method != "POST" {
+			t.Logf("non-POST method found: %s %s -> %s", c.Method, c.Path, c.OperationID)
+		}
+		if c.OperationID == "" {
+			t.Errorf("empty operationId for path: %s", c.Path)
+		}
+	}
+
+	// Count unique tags
+	tags := make(map[string]int)
+	for _, c := range cmds {
+		for _, tag := range c.Tags {
+			tags[tag]++
+		}
+	}
+	t.Logf("Unique tags (%d):", len(tags))
+	for tag, count := range tags {
+		mapped, ok := TagNameMap[tag]
+		t.Logf("  %s (%s) -> %d operations [mapped: %s, known: %v]", tag, mapped, count, mapped, ok)
+	}
+
+	// Check body params extraction
+	withBody := 0
+	withParams := 0
+	for _, c := range cmds {
+		if c.HasBody {
+			withBody++
+		}
+		if len(c.BodyParams) > 0 {
+			withParams++
+		}
+	}
+	t.Logf("Commands with body: %d, with flaggable params: %d", withBody, withParams)
+}
+
+func TestCommandName(t *testing.T) {
+	tests := []struct {
+		opID      string
+		tagPrefix string
+		expected  string
+	}{
+		{"agent_detail", "agent", "detail"},
+		{"list_agent", "agent", "agent"},
+		{"get_proto_cfg", "agent", "proto_cfg"},
+		{"business_group_post", "agent", "business_group_post"}, // tagPrefix doesn't match, falls through to other prefixes
+		{"start_honeypot", "honeypot", "honeypot"},              // starts with "start_"
+		{"honey_pot_create", "honeypot", "honey_pot_create"},    // tag prefix doesn't match, falls through
+	}
+	for _, tt := range tests {
+		got := CommandName(tt.opID, tt.tagPrefix)
+		if got != tt.expected {
+			t.Errorf("CommandName(%q, %q) = %q, want %q", tt.opID, tt.tagPrefix, got, tt.expected)
+		}
+	}
+}
+
+func TestBuildCommandTree(t *testing.T) {
+	s, err := ParseSpec(spec.SpecJSON)
+	if err != nil {
+		t.Fatalf("ParseSpec failed: %v", err)
+	}
+
+	cmds, err := FlattenCommands(s)
+	if err != nil {
+		t.Fatalf("FlattenCommands failed: %v", err)
+	}
+
+	root := BuildCommandTree(cmds)
+	if root == nil {
+		t.Fatal("BuildCommandTree returned nil")
+	}
+
+	// Should have 13 tag-group parent commands
+	children := root.Commands()
+	if len(children) != len(TagNameMap) {
+		t.Errorf("expected %d parent commands, got %d", len(TagNameMap), len(children))
+	}
+
+	// Check each parent has subcommands
+	totalLeaves := 0
+	for _, child := range children {
+		leaves := child.Commands()
+		if len(leaves) == 0 {
+			t.Errorf("parent %q has no subcommands", child.Use)
+		}
+		totalLeaves += len(leaves)
+		t.Logf("  %s (%s): %d subcommands", child.Use, child.Short, len(leaves))
+	}
+
+	if totalLeaves != 257 {
+		t.Errorf("expected 257 total leaf commands, got %d", totalLeaves)
+	}
+}

--- a/products/dsensor/internal/parser/types.go
+++ b/products/dsensor/internal/parser/types.go
@@ -1,0 +1,84 @@
+package parser
+
+// Spec is a subset of OpenAPI 3.0 fields needed for CLI generation.
+type Spec struct {
+	OpenAPI    string              `json:"openapi"`
+	Info       Info                `json:"info"`
+	Paths      map[string]PathItem `json:"paths"`
+	Components Components          `json:"components,omitempty"`
+}
+
+type Info struct {
+	Title   string `json:"title"`
+	Version string `json:"version"`
+}
+
+type PathItem struct {
+	Post *Operation `json:"post,omitempty"`
+	Get  *Operation `json:"get,omitempty"`
+	Put  *Operation `json:"put,omitempty"`
+}
+
+type Operation struct {
+	OperationID string              `json:"operationId"`
+	Summary     string              `json:"summary"`
+	Description string              `json:"description"`
+	Tags        []string            `json:"tags"`
+	RequestBody *RequestBody        `json:"requestBody,omitempty"`
+	Responses   map[string]Response `json:"responses"`
+}
+
+type RequestBody struct {
+	Content  map[string]MediaType `json:"content"`
+	Required bool                 `json:"required"`
+}
+
+type MediaType struct {
+	Schema *Schema `json:"schema"`
+}
+
+type Schema struct {
+	Title        string            `json:"title"`
+	Type         string            `json:"type"`
+	Description  string            `json:"description"`
+	Properties   map[string]Schema `json:"properties"`
+	Required     []string          `json:"required"`
+	Items        *Schema           `json:"items,omitempty"`
+	Enum         []interface{}     `json:"enum,omitempty"`
+	Default      interface{}       `json:"default,omitempty"`
+	Ref          string            `json:"$ref,omitempty"`
+	AllOf        []Schema          `json:"allOf,omitempty"`
+	Minimum      *float64          `json:"minimum,omitempty"`
+	ExclusiveMin *bool             `json:"exclusiveMinimum,omitempty"`
+}
+
+type Response struct {
+	Description string               `json:"description"`
+	Content     map[string]MediaType `json:"content,omitempty"`
+}
+
+type Components struct {
+	Schemas map[string]Schema `json:"schemas"`
+}
+
+// CommandSpec represents a flattened API operation ready for command generation.
+type CommandSpec struct {
+	OperationID string
+	Summary     string
+	Tags        []string
+	Path        string
+	Method      string
+	BodyParams  []ParamSpec
+	HasBody     bool
+}
+
+// ParamSpec represents a single body parameter for flag generation.
+type ParamSpec struct {
+	Name        string
+	Type        string
+	Description string
+	Required    bool
+	Default     interface{}
+	Enum        []interface{}
+	Minimum     *float64
+}

--- a/products/dsensor/internal/spec/embed.go
+++ b/products/dsensor/internal/spec/embed.go
@@ -1,0 +1,19 @@
+package spec
+
+import "embed"
+
+// SpecFS embeds the compiled OpenAPI JSON spec into the binary.
+//
+//go:embed openapi.json
+var SpecFS embed.FS
+
+// SpecJSON returns the raw embedded spec bytes, loading once and caching.
+var SpecJSON []byte
+
+func init() {
+	var err error
+	SpecJSON, err = SpecFS.ReadFile("openapi.json")
+	if err != nil {
+		panic("failed to read embedded openapi.json: " + err.Error())
+	}
+}

--- a/products/dsensor/internal/spec/openapi.json
+++ b/products/dsensor/internal/spec/openapi.json
@@ -1,0 +1,28013 @@
+{
+  "components": {
+    "schemas": {
+      "AddNodeRet": {
+        "properties": {
+          "children": {
+            "default": [],
+            "description": "子节点信息",
+            "items": {
+              "type": "string"
+            },
+            "title": "Children",
+            "type": "array"
+          },
+          "id": {
+            "default": [],
+            "description": "节点的id",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "default": [],
+            "description": "节点名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "parent": {
+            "default": "",
+            "description": "父节点的id",
+            "title": "Parent",
+            "type": "string"
+          }
+        },
+        "title": "AddNodeRet",
+        "type": "object"
+      },
+      "AgentArgs": {
+        "properties": {
+          "id": {
+            "description": "选中探针的id",
+            "title": "Id",
+            "type": "string"
+          },
+          "network_list": {
+            "default": [],
+            "description": "探针去重后的网段列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Network List",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "AgentArgs",
+        "type": "object"
+      },
+      "AgentAttackItemDetail": {
+        "properties": {
+          "arp_count": {
+            "description": "arp志数量",
+            "title": "Arp Count",
+            "type": "integer"
+          },
+          "honeypot_event_count": {
+            "description": "入侵日志总数",
+            "title": "Honeypot Event Count",
+            "type": "integer"
+          },
+          "honeypot_event_high_count": {
+            "description": "高危威胁入侵日志数量",
+            "title": "Honeypot Event High Count",
+            "type": "integer"
+          },
+          "honeypot_event_low_count": {
+            "description": "低危威胁入侵日志数量",
+            "title": "Honeypot Event Low Count",
+            "type": "integer"
+          },
+          "honeypot_event_mid_count": {
+            "description": "中危威胁入侵日志数量",
+            "title": "Honeypot Event Mid Count",
+            "type": "integer"
+          },
+          "honeypot_event_normal_count": {
+            "description": "无威胁入侵日志数量",
+            "title": "Honeypot Event Normal Count",
+            "type": "integer"
+          },
+          "ip": {
+            "description": "被入侵的探针IP",
+            "title": "Ip",
+            "type": "string"
+          },
+          "is_deleted": {
+            "description": "探针是否被删除",
+            "title": "Is Deleted",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "被入侵的探针IP",
+            "title": "Name",
+            "type": "string"
+          },
+          "ping_count": {
+            "description": "ping日志数量",
+            "title": "Ping Count",
+            "type": "integer"
+          },
+          "scanner_count": {
+            "description": "扫描日志数量",
+            "title": "Scanner Count",
+            "type": "integer"
+          },
+          "score": {
+            "description": "攻击程度",
+            "title": "Score",
+            "type": "integer"
+          },
+          "sn": {
+            "description": "被入侵的探针ID",
+            "format": "uuid",
+            "title": "Sn",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sn",
+          "score",
+          "ip",
+          "name",
+          "is_deleted",
+          "honeypot_event_count",
+          "honeypot_event_normal_count",
+          "honeypot_event_low_count",
+          "honeypot_event_mid_count",
+          "honeypot_event_high_count",
+          "scanner_count",
+          "ping_count",
+          "arp_count"
+        ],
+        "title": "AgentAttackItemDetail",
+        "type": "object"
+      },
+      "AgentChangeTypeArg": {
+        "properties": {
+          "allagent": {
+            "description": "更改所有探针",
+            "title": "Allagent",
+            "type": "boolean"
+          },
+          "arp": {
+            "description": "arp探测开关",
+            "title": "Arp",
+            "type": "boolean"
+          },
+          "business_group": {
+            "default": "",
+            "description": "更改探针所属的业务组",
+            "title": "Business Group",
+            "type": "string"
+          },
+          "mode": {
+            "description": "更改探针的模式",
+            "title": "Mode",
+            "type": "string"
+          },
+          "name": {
+            "description": "更改探针的名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "node_sn": {
+            "description": "探针所属用户id",
+            "title": "Node Sn",
+            "type": "string"
+          },
+          "ping": {
+            "description": "ping探测开关",
+            "title": "Ping",
+            "type": "boolean"
+          },
+          "ping_detection": {
+            "description": "ping主动探测开关",
+            "title": "Ping Detection",
+            "type": "boolean"
+          },
+          "receiver": {
+            "description": "receiver服务开关",
+            "title": "Receiver",
+            "type": "boolean"
+          },
+          "sns": {
+            "default": [],
+            "description": "探针的sn列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Sns",
+            "type": "array"
+          },
+          "user_id": {
+            "description": "探针所属用户id",
+            "title": "User Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "title": "AgentChangeTypeArg",
+        "type": "object"
+      },
+      "AgentDetail": {
+        "properties": {
+          "agent_type": {
+            "description": "探针类型",
+            "title": "Agent Type",
+            "type": "string"
+          },
+          "agent_version": {
+            "description": "探针版本",
+            "title": "Agent Version",
+            "type": "integer"
+          },
+          "arp": {
+            "description": "arp 开关",
+            "title": "Arp",
+            "type": "boolean"
+          },
+          "business_group": {
+            "default": "",
+            "description": "业务组信息",
+            "title": "Business Group",
+            "type": "string"
+          },
+          "business_id": {
+            "default": "",
+            "description": "业务组id",
+            "title": "Business Id",
+            "type": "string"
+          },
+          "can_listen_ip_cnt": {
+            "description": "可监听的ip数",
+            "title": "Can Listen Ip Cnt",
+            "type": "integer"
+          },
+          "created": {
+            "description": "探针创建时间的时间戳",
+            "format": "date-time",
+            "title": "Created",
+            "type": "string"
+          },
+          "current_ip_cnt": {
+            "description": "当前ip数",
+            "title": "Current Ip Cnt",
+            "type": "string"
+          },
+          "deploy_mode": {
+            "default": "default",
+            "description": "部署模式",
+            "title": "Deploy Mode",
+            "type": "string"
+          },
+          "display_name": {
+            "description": "探针别名",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "host": {
+            "description": "探针绑定的本地地址",
+            "format": "ipvanyaddress",
+            "title": "Host",
+            "type": "string"
+          },
+          "hostname": {
+            "description": "探针所在主机名",
+            "title": "Hostname",
+            "type": "string"
+          },
+          "id": {
+            "description": "探针序列号（sn）",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "last_heartbeat": {
+            "description": "探针上次心跳时间的时间戳",
+            "format": "date-time",
+            "title": "Last Heartbeat",
+            "type": "string"
+          },
+          "last_updated": {
+            "description": "探针上次更新时间",
+            "format": "date-time",
+            "title": "Last Updated",
+            "type": "string"
+          },
+          "mode": {
+            "description": "探针模式",
+            "enum": [
+              "null",
+              "probe"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "node": {
+            "default": {},
+            "description": "探针所在节点信息",
+            "title": "Node",
+            "type": "object"
+          },
+          "os_info": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentOSInfo"
+              }
+            ],
+            "description": "探针所在主机操作系统信息",
+            "title": "Os Info"
+          },
+          "ping": {
+            "description": "ping 开关",
+            "title": "Ping",
+            "type": "boolean"
+          },
+          "ping_detection": {
+            "description": "ping detection 开关",
+            "title": "Ping Detection",
+            "type": "boolean"
+          },
+          "port_maps": {
+            "description": "绑定服务列表",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/PortmapData"
+              },
+              "type": "array"
+            },
+            "title": "Port Maps",
+            "type": "array"
+          },
+          "process_info": {
+            "description": "进程信息",
+            "title": "Process Info",
+            "type": "object"
+          },
+          "receiver": {
+            "description": "reveiver 开关",
+            "title": "Receiver",
+            "type": "boolean"
+          },
+          "scan_port_maps": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GetScanPortmapData"
+              }
+            ],
+            "description": "不绑定端口服务列表",
+            "title": "Scan Port Maps"
+          },
+          "set_proxy": {
+            "default": false,
+            "description": "探针是否使用proxyproto协议的开关",
+            "title": "Set Proxy",
+            "type": "boolean"
+          },
+          "status": {
+            "description": "探针状态",
+            "enum": [
+              "online",
+              "offline",
+              "unprobe",
+              "unnormal"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "user": {
+            "description": "探针所属用户名，用户被删除时显示“无”",
+            "title": "User",
+            "type": "string"
+          },
+          "user_id": {
+            "default": "",
+            "description": "探针所属用户id",
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "host",
+          "user",
+          "os_info",
+          "display_name",
+          "created",
+          "agent_version",
+          "agent_type",
+          "current_ip_cnt",
+          "can_listen_ip_cnt"
+        ],
+        "title": "AgentDetail",
+        "type": "object"
+      },
+      "AgentInstallStatus": {
+        "properties": {
+          "err_msg": {
+            "description": "安装失败的具体错误信息",
+            "items": {
+              "type": "string"
+            },
+            "title": "Err Msg",
+            "type": "array"
+          },
+          "fail_num": {
+            "description": "安装探针失败数",
+            "title": "Fail Num",
+            "type": "integer"
+          },
+          "install_status": {
+            "description": "安装探针的状态",
+            "enum": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "title": "Install Status",
+            "type": "integer"
+          },
+          "success_num": {
+            "description": "安装探针成功数",
+            "title": "Success Num",
+            "type": "integer"
+          },
+          "sum_num": {
+            "description": "安装探针总数",
+            "title": "Sum Num",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "sum_num",
+          "success_num",
+          "fail_num",
+          "err_msg",
+          "install_status"
+        ],
+        "title": "AgentInstallStatus",
+        "type": "object"
+      },
+      "AgentListData": {
+        "properties": {
+          "ip_list": {
+            "default": [],
+            "description": "探针ip列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Ip List",
+            "type": "array"
+          }
+        },
+        "title": "AgentListData",
+        "type": "object"
+      },
+      "AgentOSInfo": {
+        "properties": {
+          "os_distrib": {
+            "description": "探针所在主机操作系统的发行版",
+            "title": "Os Distrib",
+            "type": "string"
+          },
+          "os_type": {
+            "description": "探针所在主机的操作系统",
+            "enum": [
+              "windows",
+              "linux"
+            ],
+            "title": "Os Type",
+            "type": "string"
+          },
+          "os_version": {
+            "description": "探针所在主机操作系统的版本",
+            "title": "Os Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "os_type",
+          "os_distrib",
+          "os_version"
+        ],
+        "title": "AgentOSInfo",
+        "type": "object"
+      },
+      "AgentUpdateInfoDetail": {
+        "properties": {
+          "update_time": {
+            "description": "探针更新时间",
+            "format": "date-time",
+            "title": "Update Time",
+            "type": "string"
+          },
+          "version": {
+            "description": "探针版本",
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "update_time",
+          "version"
+        ],
+        "title": "AgentUpdateInfoDetail",
+        "type": "object"
+      },
+      "AgentVlanDetail": {
+        "properties": {
+          "err": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DataError"
+              }
+            ],
+            "description": "错误信息",
+            "title": "Err"
+          },
+          "gateway": {
+            "description": "网关",
+            "format": "ipvanyaddress",
+            "title": "Gateway",
+            "type": "string"
+          },
+          "hardware_addr": {
+            "description": "网卡的mac地址",
+            "title": "Hardware Addr",
+            "type": "string"
+          },
+          "id": {
+            "description": "探针 vlan id）",
+            "title": "Id",
+            "type": "string"
+          },
+          "interface_name": {
+            "description": "网络接口名称",
+            "title": "Interface Name",
+            "type": "string"
+          },
+          "interface_type": {
+            "description": "网络接口类型, 1 表示管理口，2表示数据口，3表示vlan口",
+            "enum": [
+              1,
+              2,
+              3
+            ],
+            "title": "Interface Type",
+            "type": "integer"
+          },
+          "ip_count": {
+            "description": "当前网络接口下有多少ip",
+            "title": "Ip Count",
+            "type": "integer"
+          },
+          "status": {
+            "description": "网络接口的状态，0 表示未连接，1表示已连接,2 表示配置ip异常，3表示配置路由异常",
+            "enum": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "title": "Status",
+            "type": "integer"
+          },
+          "virtual_ip_list": {
+            "default": [],
+            "description": "虚拟ip列表",
+            "items": {
+              "$ref": "#/components/schemas/VirtualIPDetail"
+            },
+            "title": "Virtual Ip List",
+            "type": "array"
+          },
+          "vlan_id": {
+            "description": "网络接口所属Vlan",
+            "title": "Vlan Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "interface_name",
+          "interface_type",
+          "status",
+          "vlan_id",
+          "ip_count"
+        ],
+        "title": "AgentVlanDetail",
+        "type": "object"
+      },
+      "AgentVlanIPConfig": {
+        "properties": {
+          "gateway": {
+            "default": "",
+            "description": "网关地址",
+            "title": "Gateway",
+            "type": "string"
+          },
+          "interface_name": {
+            "description": "网口名称",
+            "title": "Interface Name",
+            "type": "string"
+          },
+          "interface_type": {
+            "description": "网口类型,1 表示管理口，2表示数据口，3表示vlan口",
+            "enum": [
+              1,
+              2,
+              3
+            ],
+            "title": "Interface Type",
+            "type": "integer"
+          },
+          "virtual_ip_list": {
+            "description": "网口的所有ip地址",
+            "items": {
+              "$ref": "#/components/schemas/AgentVlanVirtualIpAddress"
+            },
+            "title": "Virtual Ip List",
+            "type": "array"
+          },
+          "vlan_id": {
+            "description": "vlan id",
+            "title": "Vlan Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "interface_name",
+          "interface_type",
+          "virtual_ip_list"
+        ],
+        "title": "AgentVlanIPConfig",
+        "type": "object"
+      },
+      "AgentVlanVirtualIpAddress": {
+        "properties": {
+          "end_ip": {
+            "description": "结束ip",
+            "format": "ipvanyaddress",
+            "title": "End Ip",
+            "type": "string"
+          },
+          "id": {
+            "description": "虚拟ip的id",
+            "title": "Id",
+            "type": "string"
+          },
+          "mask": {
+            "description": "子网掩码",
+            "title": "Mask",
+            "type": "string"
+          },
+          "start_ip": {
+            "description": "开始ip",
+            "format": "ipvanyaddress",
+            "title": "Start Ip",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "start_ip",
+          "end_ip",
+          "mask"
+        ],
+        "title": "AgentVlanVirtualIpAddress",
+        "type": "object"
+      },
+      "AlarmEmailDetail": {
+        "properties": {
+          "cc": {
+            "description": "抄送人邮箱列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Cc",
+            "type": "array"
+          },
+          "create_time": {
+            "description": "告警接收邮箱创建时间",
+            "format": "date-time",
+            "title": "Create Time",
+            "type": "string"
+          },
+          "email": {
+            "description": "告警接收邮箱地址",
+            "title": "Email",
+            "type": "string"
+          },
+          "id": {
+            "description": "告警接收邮箱id",
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_update_time": {
+            "description": "告警接收邮箱最近更新时间",
+            "format": "date-time",
+            "title": "Last Update Time",
+            "type": "string"
+          },
+          "receive_daily_report": {
+            "description": "是否订阅威胁感知统计日报",
+            "title": "Receive Daily Report",
+            "type": "boolean"
+          },
+          "receive_monthly_report": {
+            "description": "是否订阅威胁感知统计月报",
+            "title": "Receive Monthly Report",
+            "type": "boolean"
+          },
+          "receive_weekly_report": {
+            "description": "是否订阅威胁感知统计周报",
+            "title": "Receive Weekly Report",
+            "type": "boolean"
+          },
+          "receivers": {
+            "description": "告警接收范围，是否为仅本用户探针",
+            "title": "Receivers",
+            "type": "string"
+          },
+          "user": {
+            "description": "告警接收邮箱添加者id",
+            "title": "User",
+            "type": "integer"
+          },
+          "username": {
+            "description": "告警接收邮箱添加者",
+            "title": "Username",
+            "type": "string"
+          },
+          "userrole": {
+            "description": "告警接收邮箱添加者角色",
+            "title": "Userrole",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "create_time",
+          "last_update_time",
+          "receive_monthly_report",
+          "receive_weekly_report",
+          "receive_daily_report",
+          "username",
+          "userrole",
+          "email",
+          "user",
+          "receivers"
+        ],
+        "title": "AlarmEmailDetail",
+        "type": "object"
+      },
+      "AlarmEventDetail": {
+        "properties": {
+          "agent_id": {
+            "description": "连接ID",
+            "format": "uuid",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "alarm_type": {
+            "description": "告警的类型,connection为入侵日志，scanner为端口扫描日志",
+            "title": "Alarm Type",
+            "type": "string"
+          },
+          "description": {
+            "description": "概述",
+            "title": "Description",
+            "type": "string"
+          },
+          "dest_ip": {
+            "description": "目的IP地址",
+            "format": "ipvanyaddress",
+            "title": "Dest Ip",
+            "type": "string"
+          },
+          "history": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/HandleDetail"
+            },
+            "default": {},
+            "description": "处置记录",
+            "title": "History",
+            "type": "object"
+          },
+          "id": {
+            "description": "告警时间ID",
+            "title": "Id",
+            "type": "string"
+          },
+          "last_alarm_time": {
+            "description": "最后告警时间",
+            "format": "date-time",
+            "title": "Last Alarm Time",
+            "type": "string"
+          },
+          "node": {
+            "description": "节点ID",
+            "title": "Node",
+            "type": "string"
+          },
+          "risk_level": {
+            "description": "风险等级",
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
+            "title": "Risk Level",
+            "type": "integer"
+          },
+          "src_ip": {
+            "description": "源IP地址",
+            "format": "ipvanyaddress",
+            "title": "Src Ip",
+            "type": "string"
+          },
+          "status": {
+            "description": "处置状态",
+            "enum": [
+              1,
+              2,
+              3
+            ],
+            "title": "Status",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "alarm_type",
+          "status",
+          "src_ip",
+          "risk_level",
+          "description",
+          "last_alarm_time"
+        ],
+        "title": "AlarmEventDetail",
+        "type": "object"
+      },
+      "AlarmInfoDetail": {
+        "properties": {
+          "isAlarm": {
+            "default": "",
+            "description": "是否开启告警",
+            "title": "Isalarm",
+            "type": "boolean"
+          },
+          "name": {
+            "default": "",
+            "description": "告警事件类型名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "zh_CN": {
+            "default": "",
+            "description": "告警事件类型中文名称",
+            "title": "Zh Cn",
+            "type": "string"
+          }
+        },
+        "title": "AlarmInfoDetail",
+        "type": "object"
+      },
+      "AlarmRulesDetail": {
+        "properties": {
+          "agent_abnormal": {
+            "description": "探针服务异常时发出通知",
+            "title": "Agent Abnormal",
+            "type": "boolean"
+          },
+          "agent_offline": {
+            "description": "探针连接断开时发出警告",
+            "title": "Agent Offline",
+            "type": "boolean"
+          },
+          "agent_online": {
+            "description": "探针连接恢复时发出通知",
+            "title": "Agent Online",
+            "type": "boolean"
+          },
+          "aggregation": {
+            "default": false,
+            "description": "是否开启汇总告警",
+            "title": "Aggregation",
+            "type": "boolean"
+          },
+          "alarm_agents": {
+            "default": [],
+            "description": "告警的探针范围",
+            "items": {
+              "type": "string"
+            },
+            "title": "Alarm Agents",
+            "type": "array"
+          },
+          "alarm_groups": {
+            "default": [],
+            "description": "告警的业务组范围",
+            "items": {
+              "type": "string"
+            },
+            "title": "Alarm Groups",
+            "type": "array"
+          },
+          "alarm_groups_tree": {
+            "description": "告警的蜜罐范围树，用于前端显示",
+            "items": {
+              "type": "object"
+            },
+            "title": "Alarm Groups Tree",
+            "type": "array"
+          },
+          "alarm_honeynets": {
+            "default": [],
+            "description": "告警的蜜网范围",
+            "items": {
+              "type": "string"
+            },
+            "title": "Alarm Honeynets",
+            "type": "array"
+          },
+          "alarm_honeypots": {
+            "default": [],
+            "description": "告警的蜜罐范围",
+            "items": {
+              "type": "string"
+            },
+            "title": "Alarm Honeypots",
+            "type": "array"
+          },
+          "alarm_threshold_time": {
+            "default": 30,
+            "description": "威胁告警汇总间隔",
+            "minimum": 0,
+            "title": "Alarm Threshold Time",
+            "type": "integer"
+          },
+          "arp_event": {
+            "description": "检测到ARP攻击时报告",
+            "title": "Arp Event",
+            "type": "boolean"
+          },
+          "connection_event": {
+            "description": "检测到蜜罐入侵时报告",
+            "title": "Connection Event",
+            "type": "boolean"
+          },
+          "connection_event_risk_level": {
+            "description": "蜜罐入侵事件的风险级别,1表示无威胁 2表示低危, 3表示中危, 4表示高危",
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
+            "title": "Connection Event Risk Level",
+            "type": "integer"
+          },
+          "cpu_threshold_time": {
+            "description": "CPU使用率连续超过阈值且持续该时间长度后告警，以分钟为单位",
+            "minimum": 0,
+            "title": "Cpu Threshold Time",
+            "type": "integer"
+          },
+          "cpu_threshold_usage": {
+            "description": "CPU使用率阈值，为0时不告警",
+            "minimum": 0,
+            "title": "Cpu Threshold Usage",
+            "type": "number"
+          },
+          "disk_threshold_usage": {
+            "description": "磁盘占用率超过该阈值后告警，为0时不告警",
+            "minimum": 0,
+            "title": "Disk Threshold Usage",
+            "type": "number"
+          },
+          "display_name": {
+            "description": "告警配置模版名称",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "email_config_ids": {
+            "description": "邮箱ID列表",
+            "items": {},
+            "title": "Email Config Ids",
+            "type": "array"
+          },
+          "enable": {
+            "description": "是否开启告警模版",
+            "title": "Enable",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "告警配置模版id",
+            "title": "Id",
+            "type": "integer"
+          },
+          "mem_threshold_time": {
+            "description": "内存使用率连续超过阈值且持续该时间长度后告警，以分钟为单位",
+            "minimum": 0,
+            "title": "Mem Threshold Time",
+            "type": "integer"
+          },
+          "mem_threshold_usage": {
+            "description": "内存使用率阈值，为0时不告警",
+            "minimum": 0,
+            "title": "Mem Threshold Usage",
+            "type": "number"
+          },
+          "ping_event": {
+            "description": "检测到Ping扫描时报告",
+            "title": "Ping Event",
+            "type": "boolean"
+          },
+          "portrait": {
+            "description": "获取攻击者画像时报告",
+            "title": "Portrait",
+            "type": "boolean"
+          },
+          "scanner_event": {
+            "description": "检测到端口探测时报告",
+            "title": "Scanner Event",
+            "type": "boolean"
+          },
+          "smtp_config_id": {
+            "description": "邮箱配置表ID",
+            "title": "Smtp Config Id",
+            "type": "integer"
+          },
+          "type": {
+            "description": "模版类型，alert_popup弹窗告警，template告警模版",
+            "title": "Type",
+            "type": "string"
+          },
+          "user_role": {
+            "description": "模版所属用户角色",
+            "title": "User Role",
+            "type": "string"
+          },
+          "username": {
+            "description": "模版所属用户",
+            "title": "Username",
+            "type": "string"
+          },
+          "webhook_config_id": {
+            "description": "Webhook配置表ID",
+            "format": "uuid",
+            "title": "Webhook Config Id",
+            "type": "string"
+          }
+        },
+        "title": "AlarmRulesDetail",
+        "type": "object"
+      },
+      "AllCanListenIPBaseItem": {
+        "properties": {
+          "agent_sn": {
+            "description": "探针id",
+            "title": "Agent Sn",
+            "type": "string"
+          },
+          "display_name": {
+            "description": "探针名称",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "ip_list": {
+            "default": [],
+            "description": "可监听的所有ip",
+            "items": {
+              "type": "string"
+            },
+            "title": "Ip List",
+            "type": "array"
+          },
+          "listen_ip": {
+            "description": "探针ip",
+            "title": "Listen Ip",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent_sn",
+          "display_name",
+          "listen_ip"
+        ],
+        "title": "AllCanListenIPBaseItem",
+        "type": "object"
+      },
+      "AttackSourceBrief": {
+        "properties": {
+          "attack_times": {
+            "description": "入侵日志数",
+            "title": "Attack Times",
+            "type": "integer"
+          },
+          "business_group": {
+            "default": "",
+            "description": "探针所属业务组信息",
+            "title": "Business Group",
+            "type": "string"
+          },
+          "icon": {
+            "description": "溯源反制类型logo",
+            "items": {
+              "$ref": "#/components/schemas/IconType"
+            },
+            "title": "Icon",
+            "type": "array"
+          },
+          "last_attack_content": {
+            "description": "最后攻击内容",
+            "title": "Last Attack Content",
+            "type": "string"
+          },
+          "last_attack_target": {
+            "description": "最后攻击目标蜜罐",
+            "title": "Last Attack Target",
+            "type": "string"
+          },
+          "last_attack_time": {
+            "description": "最后攻击时间",
+            "format": "date-time",
+            "title": "Last Attack Time",
+            "type": "string"
+          },
+          "node": {
+            "description": "节点ID",
+            "title": "Node",
+            "type": "string"
+          },
+          "src_ip": {
+            "description": "攻击源IP",
+            "format": "ipvanyaddress",
+            "title": "Src Ip",
+            "type": "string"
+          },
+          "src_ip_location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeoLocationDetail"
+              }
+            ],
+            "description": "攻击源IP的地理位置",
+            "title": "Src Ip Location"
+          }
+        },
+        "required": [
+          "src_ip",
+          "attack_times",
+          "last_attack_target",
+          "last_attack_content",
+          "last_attack_time",
+          "icon"
+        ],
+        "title": "AttackSourceBrief",
+        "type": "object"
+      },
+      "AttackSourceDetail": {
+        "properties": {
+          "attack_times": {
+            "description": "入侵日志数",
+            "title": "Attack Times",
+            "type": "integer"
+          },
+          "business_group": {
+            "default": "",
+            "description": "探针业务组信息",
+            "title": "Business Group",
+            "type": "string"
+          },
+          "event_type_count": {
+            "description": "入侵事件类型分布",
+            "items": {
+              "$ref": "#/components/schemas/Pair_str__int_"
+            },
+            "title": "Event Type Count",
+            "type": "array"
+          },
+          "honeypot_type_count": {
+            "description": "入侵蜜罐类型分布",
+            "items": {
+              "$ref": "#/components/schemas/Pair_str__int_"
+            },
+            "title": "Honeypot Type Count",
+            "type": "array"
+          },
+          "last_attack_content": {
+            "description": "最后攻击内容",
+            "title": "Last Attack Content",
+            "type": "string"
+          },
+          "last_attack_node": {
+            "description": "最近攻击的节点ID",
+            "title": "Last Attack Node",
+            "type": "string"
+          },
+          "last_attack_target": {
+            "description": "最后攻击目标蜜罐",
+            "title": "Last Attack Target",
+            "type": "string"
+          },
+          "last_attack_time": {
+            "description": "最后攻击时间",
+            "format": "date-time",
+            "title": "Last Attack Time",
+            "type": "string"
+          },
+          "next_ip": {
+            "description": "下一个IP，可能不存在",
+            "format": "ipvanyaddress",
+            "title": "Next Ip",
+            "type": "string"
+          },
+          "portraits": {
+            "description": "攻击者画像",
+            "items": {
+              "$ref": "#/components/schemas/PortraitDetailV1"
+            },
+            "title": "Portraits",
+            "type": "array"
+          },
+          "previous_ip": {
+            "description": "上一个IP，可能不存在",
+            "format": "ipvanyaddress",
+            "title": "Previous Ip",
+            "type": "string"
+          },
+          "src_ip": {
+            "description": "攻击源IP",
+            "format": "ipvanyaddress",
+            "title": "Src Ip",
+            "type": "string"
+          },
+          "src_ip_location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeoLocationDetail"
+              }
+            ],
+            "description": "攻击源IP的地理位置",
+            "title": "Src Ip Location"
+          },
+          "threat_source": {
+            "description": "威胁数据来源",
+            "title": "Threat Source",
+            "type": "string"
+          },
+          "threat_type": {
+            "description": "威胁数据类型",
+            "title": "Threat Type",
+            "type": "string"
+          },
+          "top_agents": {
+            "description": "入侵最多的若干个探针",
+            "items": {
+              "$ref": "#/components/schemas/AgentAttackItemDetail"
+            },
+            "title": "Top Agents",
+            "type": "array"
+          },
+          "top_ips": {
+            "description": "入侵最多的若干个IP",
+            "items": {
+              "$ref": "#/components/schemas/IpAttackItemDetail"
+            },
+            "title": "Top Ips",
+            "type": "array"
+          },
+          "top_nodes": {
+            "description": "入侵最多的若干个节点",
+            "items": {
+              "$ref": "#/components/schemas/NodeAttackItemDetail"
+            },
+            "title": "Top Nodes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "src_ip",
+          "attack_times",
+          "last_attack_target",
+          "last_attack_content",
+          "top_agents",
+          "top_ips",
+          "top_nodes",
+          "event_type_count",
+          "honeypot_type_count",
+          "portraits",
+          "threat_source",
+          "threat_type"
+        ],
+        "title": "AttackSourceDetail",
+        "type": "object"
+      },
+      "AttackSourceRet": {
+        "description": "分页类响应的通用模式",
+        "properties": {
+          "data": {
+            "description": "实际返回的数据",
+            "items": {
+              "$ref": "#/components/schemas/AttackSourceBrief"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "total": {
+            "description": "满足条件的记录总数",
+            "minimum": 0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "data"
+        ],
+        "title": "AttackSourceRet",
+        "type": "object"
+      },
+      "AwsBaitAccountDetail": {
+        "properties": {
+          "aws_access_key_id": {
+            "description": "aws access key id",
+            "title": "Aws Access Key Id",
+            "type": "string"
+          },
+          "aws_secret_access_key": {
+            "description": "aws secret access key",
+            "title": "Aws Secret Access Key",
+            "type": "string"
+          },
+          "http_proxy": {
+            "description": "http代理",
+            "title": "Http Proxy",
+            "type": "string"
+          },
+          "id": {
+            "description": "aws诱饵id",
+            "title": "Id",
+            "type": "string"
+          },
+          "is_init": {
+            "description": "主账号是否初始化资源",
+            "title": "Is Init",
+            "type": "boolean"
+          },
+          "sub_aws_list": {
+            "default": [],
+            "description": "aws子账户列表",
+            "items": {
+              "$ref": "#/components/schemas/AwsBaitSubAccountDetail"
+            },
+            "title": "Sub Aws List",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "aws_access_key_id",
+          "aws_secret_access_key",
+          "http_proxy",
+          "is_init"
+        ],
+        "title": "AwsBaitAccountDetail",
+        "type": "object"
+      },
+      "AwsBaitSubAccountDetail": {
+        "properties": {
+          "aws_access_key_id": {
+            "description": "aws access key id",
+            "title": "Aws Access Key Id",
+            "type": "string"
+          },
+          "aws_secret_access_key": {
+            "description": "aws secret access key",
+            "title": "Aws Secret Access Key",
+            "type": "string"
+          },
+          "create_time": {
+            "description": "创建时间",
+            "title": "Create Time",
+            "type": "string"
+          },
+          "id": {
+            "description": "aws诱饵id",
+            "title": "Id",
+            "type": "string"
+          },
+          "region": {
+            "description": "aws区域",
+            "title": "Region",
+            "type": "string"
+          },
+          "remark": {
+            "description": "备注",
+            "title": "Remark",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "aws_access_key_id",
+          "aws_secret_access_key",
+          "region",
+          "remark",
+          "create_time"
+        ],
+        "title": "AwsBaitSubAccountDetail",
+        "type": "object"
+      },
+      "BackupBaseInfoRet": {
+        "properties": {
+          "apply_time": {
+            "description": "备份时间",
+            "format": "date-time",
+            "title": "Apply Time",
+            "type": "string"
+          },
+          "comment": {
+            "description": "备注",
+            "title": "Comment",
+            "type": "string"
+          },
+          "id": {
+            "description": "数据ID",
+            "title": "Id",
+            "type": "string"
+          },
+          "size": {
+            "description": "文件大小",
+            "title": "Size",
+            "type": "integer"
+          },
+          "status": {
+            "description": "当前状态",
+            "enum": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "title": "Status",
+            "type": "integer"
+          },
+          "system_version": {
+            "description": "适配版本",
+            "items": {
+              "type": "string"
+            },
+            "title": "System Version",
+            "type": "array"
+          },
+          "types": {
+            "description": "文件类型",
+            "items": {
+              "enum": [
+                "user",
+                "honeypot",
+                "agent",
+                "config"
+              ]
+            },
+            "title": "Types",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "types",
+          "comment",
+          "system_version",
+          "apply_time",
+          "status"
+        ],
+        "title": "BackupBaseInfoRet",
+        "type": "object"
+      },
+      "BaitEventItem": {
+        "properties": {
+          "assess_key_id": {
+            "description": "key id",
+            "title": "Assess Key Id",
+            "type": "string"
+          },
+          "end_time": {
+            "description": "结束时间",
+            "title": "End Time",
+            "type": "string"
+          },
+          "event_types": {
+            "description": "事件类型",
+            "items": {
+              "type": "string"
+            },
+            "title": "Event Types",
+            "type": "array"
+          },
+          "events": {
+            "default": [],
+            "description": "事件数据",
+            "items": {
+              "type": "object"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "id": {
+            "description": "诱饵事件id",
+            "title": "Id",
+            "type": "string"
+          },
+          "platform": {
+            "description": "云平台",
+            "title": "Platform",
+            "type": "string"
+          },
+          "remark": {
+            "description": "备注",
+            "title": "Remark",
+            "type": "string"
+          },
+          "source_ip": {
+            "description": "源ip",
+            "title": "Source Ip",
+            "type": "string"
+          },
+          "source_ip_location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeoLocationDetail"
+              }
+            ],
+            "description": "攻击源IP的地理位置",
+            "title": "Source Ip Location"
+          },
+          "start_time": {
+            "description": "开始时间",
+            "title": "Start Time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "source_ip",
+          "assess_key_id",
+          "platform",
+          "remark",
+          "event_types",
+          "start_time",
+          "end_time"
+        ],
+        "title": "BaitEventItem",
+        "type": "object"
+      },
+      "BatchClearAgentService": {
+        "properties": {
+          "agent_sn": {
+            "description": "探针",
+            "items": {
+              "type": "string"
+            },
+            "title": "Agent Sn",
+            "type": "array"
+          },
+          "node_sn": {
+            "description": "节点的sn",
+            "title": "Node Sn",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent_sn"
+        ],
+        "title": "BatchClearAgentService",
+        "type": "object"
+      },
+      "BatchDeletePortmapData": {
+        "properties": {
+          "agent_sn": {
+            "description": "探针ID",
+            "title": "Agent Sn",
+            "type": "string"
+          },
+          "end_port": {
+            "description": "结束端口",
+            "title": "End Port",
+            "type": "string"
+          },
+          "honeypot": {
+            "description": "蜜罐ID",
+            "title": "Honeypot",
+            "type": "string"
+          },
+          "node_sn": {
+            "description": "节点sn",
+            "title": "Node Sn",
+            "type": "string"
+          },
+          "proto": {
+            "description": "监听协议",
+            "title": "Proto",
+            "type": "string"
+          },
+          "start_port": {
+            "description": "起始端口",
+            "title": "Start Port",
+            "type": "string"
+          }
+        },
+        "title": "BatchDeletePortmapData",
+        "type": "object"
+      },
+      "CaptainAgentStatus": {
+        "properties": {
+          "count": {
+            "description": "探针数目",
+            "title": "Count",
+            "type": "integer"
+          },
+          "node": {
+            "description": "集中管理node id",
+            "title": "Node",
+            "type": "string"
+          },
+          "status": {
+            "description": "探针状态",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "node",
+          "status",
+          "count"
+        ],
+        "title": "CaptainAgentStatus",
+        "type": "object"
+      },
+      "CertDetail": {
+        "properties": {
+          "create_time": {
+            "description": "添加日期",
+            "format": "date-time",
+            "title": "Create Time",
+            "type": "string"
+          },
+          "id": {
+            "description": "id",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "info": {
+            "description": "cert info",
+            "title": "Info",
+            "type": "object"
+          },
+          "name": {
+            "description": "证书名称",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "info",
+          "create_time"
+        ],
+        "title": "CertDetail",
+        "type": "object"
+      },
+      "CommonDisplayName": {
+        "properties": {
+          "display_cn": {
+            "description": "中文人类可读名称",
+            "title": "Display Cn",
+            "type": "string"
+          },
+          "display_en": {
+            "description": "英文人类可读名称",
+            "title": "Display En",
+            "type": "string"
+          },
+          "name": {
+            "description": "名称",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "display_cn",
+          "display_en"
+        ],
+        "title": "CommonDisplayName",
+        "type": "object"
+      },
+      "ConfigDetail": {
+        "properties": {
+          "agent_ids": {
+            "description": "启用探针",
+            "items": {
+              "type": "string"
+            },
+            "title": "Agent Ids",
+            "type": "array"
+          },
+          "end_time": {
+            "description": "任务结束时间",
+            "title": "End Time",
+            "type": "string"
+          },
+          "start_time": {
+            "description": "任务开始时间",
+            "title": "Start Time",
+            "type": "string"
+          },
+          "status": {
+            "description": "任务状态",
+            "title": "Status",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "start_time",
+          "end_time",
+          "agent_ids",
+          "status"
+        ],
+        "title": "ConfigDetail",
+        "type": "object"
+      },
+      "ConnectionDetail": {
+        "properties": {
+          "agent_display_name": {
+            "description": "探针的人类可读名称",
+            "title": "Agent Display Name",
+            "type": "string"
+          },
+          "agent_id": {
+            "description": "探针的ID",
+            "format": "uuid",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "agent_is_deleted": {
+            "description": "探针是否被删除",
+            "title": "Agent Is Deleted",
+            "type": "boolean"
+          },
+          "business_group": {
+            "default": "",
+            "description": "探针所属的业务组信息",
+            "title": "Business Group",
+            "type": "string"
+          },
+          "dest_ip": {
+            "description": "接受连接的IP地址",
+            "format": "ipvanyaddress",
+            "title": "Dest Ip",
+            "type": "string"
+          },
+          "dest_port": {
+            "description": "接受连接的端口号",
+            "exclusiveMaximum": true,
+            "maximum": 65536,
+            "minimum": 0,
+            "title": "Dest Port",
+            "type": "integer"
+          },
+          "end_time": {
+            "description": "结束时间",
+            "format": "date-time",
+            "title": "End Time",
+            "type": "string"
+          },
+          "event_types": {
+            "default": "",
+            "description": "事件类型列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Event Types",
+            "type": "array"
+          },
+          "events": {
+            "default": "",
+            "description": "事件列表",
+            "items": {
+              "$ref": "#/components/schemas/ConnectionEventDetail"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "has_replay_file": {
+            "description": "连接是否拥有replay文件",
+            "title": "Has Replay File",
+            "type": "boolean"
+          },
+          "honeypot_display_name": {
+            "description": "蜜罐的人类可读名称",
+            "title": "Honeypot Display Name",
+            "type": "string"
+          },
+          "honeypot_id": {
+            "description": "蜜罐ID",
+            "title": "Honeypot Id",
+            "type": "string"
+          },
+          "honeypot_image_display_name": {
+            "description": "蜜罐镜像的人类可读名称",
+            "title": "Honeypot Image Display Name",
+            "type": "string"
+          },
+          "honeypot_image_name": {
+            "description": "蜜罐镜像的名称",
+            "title": "Honeypot Image Name",
+            "type": "string"
+          },
+          "id": {
+            "description": "连接ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "is_closed": {
+            "description": "是否已经关闭",
+            "title": "Is Closed",
+            "type": "boolean"
+          },
+          "log_type": {
+            "description": "日志类型： default, web",
+            "title": "Log Type",
+            "type": "string"
+          },
+          "node": {
+            "default": {},
+            "description": "节点ID",
+            "title": "Node",
+            "type": "object"
+          },
+          "pcap_file": {
+            "description": "pcap文件的下载路径",
+            "title": "Pcap File",
+            "type": "string"
+          },
+          "portrait_id": {
+            "default": "",
+            "description": "溯源日志id",
+            "title": "Portrait Id",
+            "type": "string"
+          },
+          "prev_conn": {
+            "description": "前一个连接的conn id",
+            "title": "Prev Conn",
+            "type": "string"
+          },
+          "proto": {
+            "description": "连接协议",
+            "title": "Proto",
+            "type": "string"
+          },
+          "proxy_ip": {
+            "description": "引流设备的IP地址",
+            "format": "ipvanyaddress",
+            "title": "Proxy Ip",
+            "type": "string"
+          },
+          "proxy_mode": {
+            "description": "引流设备的模式",
+            "title": "Proxy Mode",
+            "type": "string"
+          },
+          "record_file": {
+            "description": "连接的录屏文件，若后缀为.m3u8,是hls直播文件，若后缀是.mp4,是完成后的录播",
+            "title": "Record File",
+            "type": "string"
+          },
+          "risk_level": {
+            "description": "风险等级",
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
+            "title": "Risk Level",
+            "type": "integer"
+          },
+          "src_honeypot": {
+            "description": "跳板蜜罐的人类可读名称",
+            "title": "Src Honeypot",
+            "type": "string"
+          },
+          "src_ip": {
+            "description": "发起连接的IP地址",
+            "format": "ipvanyaddress",
+            "title": "Src Ip",
+            "type": "string"
+          },
+          "src_ip_location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeoLocationDetail"
+              }
+            ],
+            "description": "发起连接的IP的归属地信息",
+            "title": "Src Ip Location"
+          },
+          "src_mac": {
+            "description": "发起连接的MAC地址",
+            "title": "Src Mac",
+            "type": "string"
+          },
+          "src_port": {
+            "description": "发起连接的端口号",
+            "exclusiveMaximum": true,
+            "maximum": 65536,
+            "minimum": 0,
+            "title": "Src Port",
+            "type": "integer"
+          },
+          "start_time": {
+            "description": "开始时间",
+            "format": "date-time",
+            "title": "Start Time",
+            "type": "string"
+          },
+          "tools": {
+            "default": "",
+            "description": "扫描工具类型列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tools",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "agent_is_deleted",
+          "risk_level",
+          "start_time",
+          "src_ip"
+        ],
+        "title": "ConnectionDetail",
+        "type": "object"
+      },
+      "ConnectionEventDetail": {
+        "properties": {
+          "event_type_display_name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommonDisplayName"
+              }
+            ],
+            "description": "事件类型名称描述",
+            "title": "Event Type Display Name"
+          },
+          "extra": {
+            "description": "extra的描述信息",
+            "title": "Extra",
+            "type": "object"
+          },
+          "file_info": {
+            "description": "文件信息",
+            "format": "uuid",
+            "title": "File Info",
+            "type": "string"
+          },
+          "id": {
+            "description": "事件的ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "risk_level": {
+            "description": "风险等级",
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
+            "title": "Risk Level",
+            "type": "integer"
+          },
+          "time": {
+            "description": "连接事件时间",
+            "title": "Time",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "risk_level",
+          "event_type_display_name",
+          "time"
+        ],
+        "title": "ConnectionEventDetail",
+        "type": "object"
+      },
+      "CpuMemStatDetail": {
+        "properties": {
+          "cpu": {
+            "description": "CPU 使用率",
+            "title": "Cpu",
+            "type": "number"
+          },
+          "mem": {
+            "description": "内存使用率",
+            "title": "Mem",
+            "type": "number"
+          },
+          "time": {
+            "description": "当前系统时间",
+            "title": "Time",
+            "type": "number"
+          }
+        },
+        "required": [
+          "cpu",
+          "mem",
+          "time"
+        ],
+        "title": "CpuMemStatDetail",
+        "type": "object"
+      },
+      "CpuMemStatStrDetail": {
+        "properties": {
+          "cpu": {
+            "description": "CPU 使用率",
+            "title": "Cpu",
+            "type": "string"
+          },
+          "mem": {
+            "description": "内存使用率",
+            "title": "Mem",
+            "type": "string"
+          },
+          "time": {
+            "description": "当前系统时间",
+            "title": "Time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cpu",
+          "mem",
+          "time"
+        ],
+        "title": "CpuMemStatStrDetail",
+        "type": "object"
+      },
+      "CreateHoneypotPresetBaseArg": {
+        "properties": {
+          "copy_preset": {
+            "description": "复制模版的ID",
+            "title": "Copy Preset",
+            "type": "string"
+          },
+          "meta": {
+            "description": "模版信息（蜜罐中template的信息）",
+            "title": "Meta",
+            "type": "object"
+          }
+        },
+        "required": [
+          "meta"
+        ],
+        "title": "CreateHoneypotPresetBaseArg",
+        "type": "object"
+      },
+      "CreateRecommendService": {
+        "properties": {
+          "id": {
+            "description": "服务id",
+            "title": "Id",
+            "type": "string"
+          },
+          "network": {
+            "description": "网段",
+            "title": "Network",
+            "type": "string"
+          },
+          "recommend_groups": {
+            "default": [],
+            "description": "推荐蜜罐组合",
+            "items": {},
+            "title": "Recommend Groups",
+            "type": "array"
+          },
+          "recommend_honeypots": {
+            "description": "推荐蜜罐服务",
+            "items": {
+              "type": "string"
+            },
+            "title": "Recommend Honeypots",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "network",
+          "recommend_honeypots"
+        ],
+        "title": "CreateRecommendService",
+        "type": "object"
+      },
+      "DataError": {
+        "properties": {
+          "err": {
+            "description": "错误key",
+            "title": "Err",
+            "type": "string"
+          },
+          "msg": {
+            "description": "错误内容",
+            "title": "Msg",
+            "type": "string"
+          },
+          "role": {
+            "description": "角色",
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "title": "DataError",
+        "type": "object"
+      },
+      "DumbCapture": {
+        "properties": {
+          "data": {
+            "description": "扫描内容",
+            "title": "Data",
+            "type": "string"
+          },
+          "port": {
+            "description": "扫描的端口",
+            "title": "Port",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "port",
+          "data"
+        ],
+        "title": "DumbCapture",
+        "type": "object"
+      },
+      "EmailBaitDetail": {
+        "properties": {
+          "bait_name": {
+            "description": "诱饵名称",
+            "title": "Bait Name",
+            "type": "string"
+          },
+          "email_address": {
+            "description": "发送邮箱地址",
+            "title": "Email Address",
+            "type": "string"
+          },
+          "email_attachment_paths": {
+            "default": [],
+            "description": "附件路径",
+            "items": {
+              "type": "string"
+            },
+            "title": "Email Attachment Paths",
+            "type": "array"
+          },
+          "email_content": {
+            "description": "邮件内容",
+            "title": "Email Content",
+            "type": "string"
+          },
+          "email_password": {
+            "description": "发送邮箱密码",
+            "title": "Email Password",
+            "type": "string"
+          },
+          "email_recipients": {
+            "description": "收件人",
+            "items": {
+              "type": "string"
+            },
+            "title": "Email Recipients",
+            "type": "array"
+          },
+          "email_title": {
+            "description": "邮件名称",
+            "title": "Email Title",
+            "type": "string"
+          },
+          "encrypt_type": {
+            "description": "加密类型",
+            "title": "Encrypt Type",
+            "type": "string"
+          },
+          "generate_type": {
+            "description": "生成类型",
+            "title": "Generate Type",
+            "type": "integer"
+          },
+          "honeypot_addr": {
+            "description": "蜜罐地址",
+            "title": "Honeypot Addr",
+            "type": "string"
+          },
+          "honeypot_image": {
+            "description": "蜜罐镜像",
+            "title": "Honeypot Image",
+            "type": "string"
+          },
+          "id": {
+            "description": "id",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "no_key": {
+            "description": "是否需要密钥",
+            "title": "No Key",
+            "type": "boolean"
+          },
+          "node": {
+            "description": "节点id",
+            "title": "Node",
+            "type": "string"
+          },
+          "scene": {
+            "description": "使用场景",
+            "title": "Scene",
+            "type": "string"
+          },
+          "send_status": {
+            "description": "发送状态",
+            "title": "Send Status",
+            "type": "integer"
+          },
+          "send_time": {
+            "description": "发送时间",
+            "title": "Send Time",
+            "type": "string"
+          },
+          "smtp_port": {
+            "description": "smtp端口",
+            "title": "Smtp Port",
+            "type": "integer"
+          },
+          "smtp_server": {
+            "description": "smtp服务器",
+            "title": "Smtp Server",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "bait_name",
+          "smtp_server",
+          "smtp_port",
+          "email_address",
+          "email_password",
+          "email_recipients",
+          "no_key",
+          "encrypt_type",
+          "generate_type",
+          "scene",
+          "honeypot_image",
+          "honeypot_addr",
+          "node",
+          "email_title",
+          "email_content",
+          "send_time",
+          "send_status"
+        ],
+        "title": "EmailBaitDetail",
+        "type": "object"
+      },
+      "EmailIPWhiteListDetail": {
+        "description": "告警白名单规则\n\n目前支持的语法规则使用自然语言描述为:\n1. 整体规则形如“来源部分;目的部分”，两部分至少存在一个，且仅有来源部分时，分号分隔符可选\n2. 每部分形如“网段:端口列表”，网段和端口列表至少存在一个，且仅有网段时，冒号分隔符可选，网段为IPv6地址且包含端口列表时，必须使用中括号包裹网段\n3. 网段可以表述为“地址/前缀长度”，当地址为IPv4且前缀长度为32时，斜线分隔符和前缀长度可选，当地址为IPv6且前缀长度为128时，斜线分隔符和前缀长度可选\n4. 端口区间列表表示为多个以“,”分隔的端口区间\n5. 端口区间形如“最小端口号-最大端口号”，当最小端口号和最大端口号相等时，可表示为“端口号”",
+        "properties": {
+          "apply_user": {
+            "description": "生效用户",
+            "enum": [
+              "only_me",
+              "all"
+            ],
+            "title": "Apply User"
+          },
+          "from_addr": {
+            "description": "来源IP，形如“1.1.1.1/24”、“1.1.1.1”",
+            "title": "From Addr",
+            "type": "string"
+          },
+          "from_mc": {
+            "default": false,
+            "description": "为True时，来自集中管理平台，不可编辑",
+            "title": "From Mc",
+            "type": "boolean"
+          },
+          "from_port": {
+            "description": "来源端口，形如“1-10,22,200-2000,5432”",
+            "title": "From Port",
+            "type": "string"
+          },
+          "handle": {
+            "default": "access",
+            "description": "access表示可访问蜜罐但不记录日志，reject表示不可访问蜜罐",
+            "title": "Handle",
+            "type": "string"
+          },
+          "id": {
+            "description": "白名单记录的ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "protocol": {
+            "default": "",
+            "description": "白名单针对的协议，形如“tcp”、“”、“udp”、“icmp”",
+            "title": "Protocol",
+            "type": "string"
+          },
+          "remark_text": {
+            "description": "备注",
+            "title": "Remark Text",
+            "type": "string"
+          },
+          "save_event": {
+            "default": true,
+            "description": "为True时，对符合这条白名单配置的内容进行记录",
+            "title": "Save Event",
+            "type": "boolean"
+          },
+          "send_email": {
+            "default": true,
+            "description": "为True时，对符合这条白名单配置的内容进行邮件告警",
+            "title": "Send Email",
+            "type": "boolean"
+          },
+          "send_syslog": {
+            "default": true,
+            "description": "为True时，对符合这条白名单配置的内容发送syslog",
+            "title": "Send Syslog",
+            "type": "boolean"
+          },
+          "to_addr": {
+            "description": "目的IP，形如“1.1.1.1/24”、“1.1.1.1”",
+            "title": "To Addr",
+            "type": "string"
+          },
+          "to_port": {
+            "description": "目的端口，形如“1-10,22,200-2000,5432”",
+            "title": "To Port",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "apply_user"
+        ],
+        "title": "EmailIPWhiteListDetail",
+        "type": "object"
+      },
+      "EventReportDetail": {
+        "properties": {
+          "create_method": {
+            "description": "报告创建方式",
+            "title": "Create Method",
+            "type": "string"
+          },
+          "create_time": {
+            "description": "报告的创建时间",
+            "title": "Create Time",
+            "type": "number"
+          },
+          "creator": {
+            "description": "报告的创建者",
+            "title": "Creator",
+            "type": "string"
+          },
+          "end_time": {
+            "description": "报告的结束时间",
+            "title": "End Time",
+            "type": "integer"
+          },
+          "name": {
+            "description": "报告的名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "rid": {
+            "description": "报告的uuid",
+            "title": "Rid",
+            "type": "string"
+          },
+          "start_time": {
+            "description": "报告的开始时间",
+            "title": "Start Time",
+            "type": "integer"
+          },
+          "type": {
+            "description": "报告的类型",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "rid",
+          "name",
+          "type",
+          "start_time",
+          "end_time",
+          "creator",
+          "create_time",
+          "create_method"
+        ],
+        "title": "EventReportDetail",
+        "type": "object"
+      },
+      "EventTimeLine": {
+        "properties": {
+          "count": {
+            "description": "数量",
+            "title": "Count",
+            "type": "integer"
+          },
+          "start_time": {
+            "description": "开始时间",
+            "format": "date-time",
+            "title": "Start Time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start_time",
+          "count"
+        ],
+        "title": "EventTimeLine",
+        "type": "object"
+      },
+      "FetchPresetData": {
+        "properties": {
+          "file_info": {
+            "description": "模版文件信息",
+            "title": "File Info",
+            "type": "object"
+          },
+          "meta": {
+            "description": "模版meta信息",
+            "title": "Meta",
+            "type": "object"
+          },
+          "preset_id": {
+            "description": "模版ID",
+            "title": "Preset Id",
+            "type": "string"
+          },
+          "type": {
+            "description": "模版类型",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "meta",
+          "file_info",
+          "type",
+          "preset_id"
+        ],
+        "title": "FetchPresetData",
+        "type": "object"
+      },
+      "FirewallConfigDetail": {
+        "properties": {
+          "addr": {
+            "description": "三方设备地址",
+            "title": "Addr",
+            "type": "string"
+          },
+          "agent_ips": {
+            "description": "牧云探针ip列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Agent Ips",
+            "type": "array"
+          },
+          "api_token": {
+            "default": "",
+            "description": "三方设备api-token",
+            "title": "Api Token",
+            "type": "string"
+          },
+          "device_type": {
+            "description": "设备类型",
+            "title": "Device Type",
+            "type": "integer"
+          },
+          "display_name": {
+            "description": "设备名称",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "id": {
+            "description": "设备id",
+            "title": "Id",
+            "type": "integer"
+          },
+          "password": {
+            "default": "",
+            "description": "三方设备登录密码",
+            "title": "Password",
+            "type": "string"
+          },
+          "remark": {
+            "description": "备注",
+            "title": "Remark",
+            "type": "string"
+          },
+          "status": {
+            "default": true,
+            "description": "设备状态，true为启用，false为禁用",
+            "title": "Status",
+            "type": "boolean"
+          },
+          "username": {
+            "default": "",
+            "description": "三方设备登录用户名",
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "title": "FirewallConfigDetail",
+        "type": "object"
+      },
+      "FirewallRuleDetail": {
+        "properties": {
+          "alarm_agents": {
+            "default": [],
+            "description": "告警的探针范围",
+            "items": {
+              "type": "string"
+            },
+            "title": "Alarm Agents",
+            "type": "array"
+          },
+          "alarm_groups": {
+            "default": [],
+            "description": "告警的业务组范围",
+            "items": {
+              "type": "string"
+            },
+            "title": "Alarm Groups",
+            "type": "array"
+          },
+          "alarm_groups_tree": {
+            "description": "告警的蜜罐范围树，用于前端显示",
+            "items": {
+              "type": "object"
+            },
+            "title": "Alarm Groups Tree",
+            "type": "array"
+          },
+          "alarm_honeynets": {
+            "default": [],
+            "description": "告警的蜜网范围",
+            "items": {
+              "type": "string"
+            },
+            "title": "Alarm Honeynets",
+            "type": "array"
+          },
+          "alarm_honeypots": {
+            "default": [],
+            "description": "告警的蜜罐范围",
+            "items": {
+              "type": "string"
+            },
+            "title": "Alarm Honeypots",
+            "type": "array"
+          },
+          "arp_event": {
+            "description": "检测到ARP攻击时报告",
+            "title": "Arp Event",
+            "type": "boolean"
+          },
+          "connection_event": {
+            "description": "检测到蜜罐入侵时报告",
+            "title": "Connection Event",
+            "type": "boolean"
+          },
+          "connection_event_risk_level": {
+            "description": "蜜罐入侵事件的风险级别,1表示无威胁 2表示低危, 3表示中危, 4表示高危",
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
+            "title": "Connection Event Risk Level",
+            "type": "integer"
+          },
+          "enable": {
+            "default": true,
+            "description": "是否开启告警模版",
+            "title": "Enable",
+            "type": "boolean"
+          },
+          "firewall_config_ids": {
+            "default": [],
+            "description": "防火墙配置id列表",
+            "items": {
+              "type": "integer"
+            },
+            "title": "Firewall Config Ids",
+            "type": "array"
+          },
+          "ping_event": {
+            "description": "检测到Ping扫描时报告",
+            "title": "Ping Event",
+            "type": "boolean"
+          },
+          "portrait": {
+            "description": "获取攻击者画像时报告",
+            "title": "Portrait",
+            "type": "boolean"
+          },
+          "scanner_event": {
+            "description": "检测到端口探测时报告",
+            "title": "Scanner Event",
+            "type": "boolean"
+          },
+          "type": {
+            "default": 3,
+            "description": "模版类型，alert_popup弹窗告警，template告警模版，firewall防火墙规则",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "portrait",
+          "connection_event",
+          "connection_event_risk_level",
+          "scanner_event",
+          "ping_event",
+          "arp_event"
+        ],
+        "title": "FirewallRuleDetail",
+        "type": "object"
+      },
+      "GeoLocationDetail": {
+        "description": "IP归属地信息",
+        "properties": {
+          "catagory": {
+            "description": "IP类型",
+            "title": "Catagory",
+            "type": "string"
+          },
+          "city_name": {
+            "description": "归属地城市",
+            "title": "City Name",
+            "type": "string"
+          },
+          "country_name": {
+            "description": "归属地国家",
+            "title": "Country Name",
+            "type": "string"
+          },
+          "ip": {
+            "description": "IP",
+            "format": "ipvanyaddress",
+            "title": "Ip",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ip",
+          "catagory"
+        ],
+        "title": "GeoLocationDetail",
+        "type": "object"
+      },
+      "GetArchiveFileIdDetail": {
+        "properties": {
+          "id": {
+            "description": "用于后续下载的文件ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "path"
+        ],
+        "title": "GetArchiveFileIdDetail",
+        "type": "object"
+      },
+      "GetBaitDownloadToken": {
+        "properties": {
+          "id": {
+            "description": "用于后续下载的文件ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "path": {
+            "description": "下载路径",
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "path"
+        ],
+        "title": "GetBaitDownloadToken",
+        "type": "object"
+      },
+      "GetEventId": {
+        "properties": {
+          "desc": {
+            "default": "",
+            "description": "描述信息",
+            "title": "Desc",
+            "type": "string"
+          },
+          "id": {
+            "description": "用于后续下载的文件ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "path"
+        ],
+        "title": "GetEventId",
+        "type": "object"
+      },
+      "GetFullRet": {
+        "properties": {
+          "data": {
+            "default": [],
+            "description": "整个树的结构",
+            "items": {
+              "type": "object"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "title": "GetFullRet",
+        "type": "object"
+      },
+      "GetPingId": {
+        "properties": {
+          "id": {
+            "description": "用于后续下载的文件ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "path"
+        ],
+        "title": "GetPingId",
+        "type": "object"
+      },
+      "GetPortraitId": {
+        "properties": {
+          "id": {
+            "description": "用于后续下载的文件ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "path"
+        ],
+        "title": "GetPortraitId",
+        "type": "object"
+      },
+      "GetPortraitParamData": {
+        "properties": {
+          "external_ips": {
+            "description": "代理IP数据",
+            "items": {
+              "$ref": "#/components/schemas/GetPortraitParamItem"
+            },
+            "title": "External Ips",
+            "type": "array"
+          },
+          "honeypots": {
+            "description": "蜜罐数据",
+            "items": {
+              "$ref": "#/components/schemas/GetPortraitParamItem"
+            },
+            "title": "Honeypots",
+            "type": "array"
+          },
+          "real_ips": {
+            "description": "真实外网IP数据",
+            "items": {
+              "$ref": "#/components/schemas/GetPortraitParamItem"
+            },
+            "title": "Real Ips",
+            "type": "array"
+          },
+          "src_ips": {
+            "description": "直接攻击IP数据",
+            "items": {
+              "$ref": "#/components/schemas/GetPortraitParamItem"
+            },
+            "title": "Src Ips",
+            "type": "array"
+          }
+        },
+        "required": [
+          "src_ips",
+          "real_ips",
+          "external_ips",
+          "honeypots"
+        ],
+        "title": "GetPortraitParamData",
+        "type": "object"
+      },
+      "GetPortraitParamItem": {
+        "properties": {
+          "value": {
+            "default": "",
+            "description": "参数真正对应的值",
+            "title": "Value",
+            "type": "string"
+          },
+          "verbose": {
+            "default": "",
+            "description": "参数显示内容",
+            "title": "Verbose",
+            "type": "string"
+          }
+        },
+        "title": "GetPortraitParamItem",
+        "type": "object"
+      },
+      "GetScanPortmapData": {
+        "properties": {
+          "err": {
+            "description": "错误信息",
+            "items": {
+              "$ref": "#/components/schemas/PortmapDataError"
+            },
+            "title": "Err",
+            "type": "array"
+          },
+          "ports": {
+            "default": [],
+            "description": "端口列表",
+            "items": {
+              "$ref": "#/components/schemas/ScanPortmaps"
+            },
+            "title": "Ports",
+            "type": "array"
+          },
+          "service_ips": {
+            "default": [],
+            "description": "服务ip列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Service Ips",
+            "type": "array"
+          },
+          "status": {
+            "description": "状态",
+            "title": "Status",
+            "type": "integer"
+          }
+        },
+        "title": "GetScanPortmapData",
+        "type": "object"
+      },
+      "GetScannerId": {
+        "properties": {
+          "id": {
+            "description": "用于后续下载的文件ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "path"
+        ],
+        "title": "GetScannerId",
+        "type": "object"
+      },
+      "GetUserProfileDetail": {
+        "properties": {
+          "api_token": {
+            "description": "经过遮盖的api token，当前用户未生成token时为None",
+            "title": "Api Token",
+            "type": "string"
+          },
+          "create_time": {
+            "description": "用户创建时间",
+            "title": "Create Time",
+            "type": "string"
+          },
+          "ip_policy": {
+            "description": "用户的IP策略",
+            "items": {
+              "type": "string"
+            },
+            "title": "Ip Policy",
+            "type": "array"
+          },
+          "ip_policy_mode": {
+            "description": "用户IP策略模式",
+            "enum": [
+              "allow",
+              "deny"
+            ],
+            "title": "Ip Policy Mode"
+          },
+          "last_change_password": {
+            "description": "用户上次修改密码的时间",
+            "format": "date-time",
+            "title": "Last Change Password",
+            "type": "string"
+          },
+          "login_method": {
+            "description": "用户登录方式",
+            "enum": [
+              "cert",
+              "password",
+              "ldap",
+              "radius"
+            ],
+            "title": "Login Method"
+          },
+          "old_pwd": {
+            "default": [],
+            "description": "用户旧密码的Hash值",
+            "items": {
+              "type": "string"
+            },
+            "title": "Old Pwd",
+            "type": "array"
+          },
+          "role": {
+            "description": "用户角色",
+            "enum": [
+              "superAdmin",
+              "admin",
+              "auditor",
+              "tenant",
+              "log_observer"
+            ],
+            "title": "Role"
+          },
+          "session_timeout": {
+            "description": "用户会话过期时间",
+            "format": "time-delta",
+            "title": "Session Timeout",
+            "type": "number"
+          },
+          "totp_active": {
+            "description": "用户是否开启TOTP",
+            "title": "Totp Active",
+            "type": "boolean"
+          },
+          "user_type": {
+            "description": "用户类型",
+            "enum": [
+              "normal",
+              "internal"
+            ],
+            "title": "User Type"
+          },
+          "username": {
+            "description": "用户名",
+            "title": "Username",
+            "type": "string"
+          },
+          "ws_token": {
+            "description": "websocket的token",
+            "title": "Ws Token",
+            "type": "string"
+          }
+        },
+        "title": "GetUserProfileDetail",
+        "type": "object"
+      },
+      "HandleDetail": {
+        "properties": {
+          "status": {
+            "description": "处置状态",
+            "enum": [
+              1,
+              2,
+              3
+            ],
+            "title": "Status",
+            "type": "integer"
+          },
+          "text": {
+            "description": "处置记录",
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "text"
+        ],
+        "title": "HandleDetail",
+        "type": "object"
+      },
+      "HoneynetScriptDetail": {
+        "properties": {
+          "description": {
+            "default": "",
+            "description": "模板描述",
+            "title": "Description",
+            "type": "string"
+          },
+          "id": {
+            "description": "模板ID",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "description": "模板名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "port_maps": {
+            "description": "服务列表",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/PortmapData"
+              },
+              "type": "array"
+            },
+            "title": "Port Maps",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "HoneynetScriptDetail",
+        "type": "object"
+      },
+      "HoneypotBaseItem": {
+        "properties": {
+          "container_id": {
+            "description": "蜜罐容器ID",
+            "title": "Container Id",
+            "type": "string"
+          },
+          "created": {
+            "description": "蜜罐创建时间",
+            "title": "Created",
+            "type": "number"
+          },
+          "display_name": {
+            "description": "蜜罐名称",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "honeynets": {
+            "description": "蜜网ID列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Honeynets",
+            "type": "array"
+          },
+          "id": {
+            "description": "蜜罐ID",
+            "title": "Id",
+            "type": "string"
+          },
+          "image": {
+            "description": "蜜罐镜像名称（含版本），类似honeypot/wiki:latest",
+            "title": "Image",
+            "type": "string"
+          },
+          "image_display_name": {
+            "description": "蜜罐镜像名称，类似Wiki",
+            "title": "Image Display Name",
+            "type": "string"
+          },
+          "image_version": {
+            "description": "蜜罐镜像版本号",
+            "title": "Image Version",
+            "type": "string"
+          },
+          "node_msg": {
+            "default": {},
+            "description": "节点信息",
+            "title": "Node Msg",
+            "type": "object"
+          },
+          "preset": {
+            "description": "蜜罐模版",
+            "title": "Preset",
+            "type": "string"
+          },
+          "preset_name": {
+            "description": "模版名称",
+            "title": "Preset Name",
+            "type": "string"
+          },
+          "proto": {
+            "description": "蜜罐协议",
+            "title": "Proto",
+            "type": "string"
+          },
+          "state": {
+            "description": "蜜罐状态列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "State",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "container_id",
+          "display_name",
+          "image",
+          "image_version",
+          "image_display_name",
+          "preset",
+          "created",
+          "honeynets",
+          "preset_name",
+          "proto",
+          "state"
+        ],
+        "title": "HoneypotBaseItem",
+        "type": "object"
+      },
+      "HoneypotConfigDetail": {
+        "properties": {
+          "cycle": {
+            "default": 0,
+            "description": "周期",
+            "title": "Cycle",
+            "type": "integer"
+          }
+        },
+        "title": "HoneypotConfigDetail",
+        "type": "object"
+      },
+      "HoneypotListDetail": {
+        "properties": {
+          "container_id": {
+            "description": "蜜罐container_id",
+            "title": "Container Id",
+            "type": "string"
+          },
+          "created": {
+            "description": "蜜罐创建时间",
+            "title": "Created",
+            "type": "number"
+          },
+          "display_name": {
+            "description": "蜜罐display_name",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "honeynets": {
+            "default": [],
+            "description": "蜜网id",
+            "items": {
+              "type": "string"
+            },
+            "title": "Honeynets",
+            "type": "array"
+          },
+          "id": {
+            "description": "蜜罐id",
+            "title": "Id",
+            "type": "string"
+          },
+          "image": {
+            "description": "蜜罐镜像",
+            "title": "Image",
+            "type": "string"
+          },
+          "image_display_name": {
+            "description": "蜜罐镜像display_name",
+            "title": "Image Display Name",
+            "type": "string"
+          },
+          "image_version": {
+            "description": "蜜罐镜像版本",
+            "title": "Image Version",
+            "type": "string"
+          },
+          "ip_list": {
+            "default": [],
+            "description": "蜜罐ip",
+            "items": {
+              "type": "string"
+            },
+            "title": "Ip List",
+            "type": "array"
+          },
+          "name": {
+            "description": "蜜罐名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "node": {
+            "description": "节点ID",
+            "title": "Node",
+            "type": "string"
+          },
+          "node_msg": {
+            "default": {},
+            "description": "节点信息",
+            "title": "Node Msg",
+            "type": "object"
+          },
+          "preset": {
+            "default": "",
+            "description": "蜜罐的模板id",
+            "title": "Preset",
+            "type": "string"
+          },
+          "preset_name": {
+            "default": "",
+            "description": "蜜罐的模板名称",
+            "title": "Preset Name",
+            "type": "string"
+          },
+          "proto": {
+            "default": "",
+            "description": "协议",
+            "title": "Proto",
+            "type": "string"
+          },
+          "state": {
+            "description": "蜜罐的状态",
+            "items": {
+              "enum": [
+                "exited",
+                "disconnected",
+                "created",
+                "running",
+                "dead",
+                "restarting",
+                "upgrade",
+                "forbidden",
+                "upgrade_portrait"
+              ],
+              "type": "string"
+            },
+            "title": "State",
+            "type": "array"
+          },
+          "uptime": {
+            "default": 0,
+            "description": "蜜罐的启动时间",
+            "title": "Uptime",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "container_id",
+          "display_name",
+          "name",
+          "image",
+          "image_version",
+          "state",
+          "created"
+        ],
+        "title": "HoneypotListDetail",
+        "type": "object"
+      },
+      "HoneypotPresetBaseArg": {
+        "properties": {
+          "copy_preset": {
+            "description": "复制模版的ID",
+            "title": "Copy Preset",
+            "type": "string"
+          },
+          "meta": {
+            "description": "模版信息（蜜罐中template的信息）",
+            "title": "Meta",
+            "type": "object"
+          }
+        },
+        "required": [
+          "meta"
+        ],
+        "title": "HoneypotPresetBaseArg",
+        "type": "object"
+      },
+      "IconType": {
+        "properties": {
+          "icon_min": {
+            "title": "Icon Min",
+            "type": "string"
+          },
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "title",
+          "icon_min"
+        ],
+        "title": "IconType",
+        "type": "object"
+      },
+      "IpAttackItemDetail": {
+        "properties": {
+          "arp_count": {
+            "description": "arp志数量",
+            "title": "Arp Count",
+            "type": "integer"
+          },
+          "honeypot_event_count": {
+            "description": "入侵日志总数",
+            "title": "Honeypot Event Count",
+            "type": "integer"
+          },
+          "honeypot_event_high_count": {
+            "description": "高危威胁入侵日志数量",
+            "title": "Honeypot Event High Count",
+            "type": "integer"
+          },
+          "honeypot_event_low_count": {
+            "description": "低危威胁入侵日志数量",
+            "title": "Honeypot Event Low Count",
+            "type": "integer"
+          },
+          "honeypot_event_mid_count": {
+            "description": "中危威胁入侵日志数量",
+            "title": "Honeypot Event Mid Count",
+            "type": "integer"
+          },
+          "honeypot_event_normal_count": {
+            "description": "无威胁入侵日志数量",
+            "title": "Honeypot Event Normal Count",
+            "type": "integer"
+          },
+          "ip": {
+            "description": "攻击的IP",
+            "title": "Ip",
+            "type": "string"
+          },
+          "scanner_count": {
+            "description": "扫描日志数量",
+            "title": "Scanner Count",
+            "type": "integer"
+          },
+          "score": {
+            "description": "攻击程度",
+            "title": "Score",
+            "type": "integer"
+          },
+          "sn": {
+            "description": "被入侵的探针ID",
+            "format": "uuid",
+            "title": "Sn",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ip",
+          "sn",
+          "score",
+          "honeypot_event_count",
+          "honeypot_event_normal_count",
+          "honeypot_event_low_count",
+          "honeypot_event_mid_count",
+          "honeypot_event_high_count",
+          "scanner_count",
+          "arp_count"
+        ],
+        "title": "IpAttackItemDetail",
+        "type": "object"
+      },
+      "KafkaConfigDetail": {
+        "properties": {
+          "ack_type": {
+            "description": "kafka的响应方式",
+            "enum": [
+              "none",
+              "wait_leader",
+              "wait_all"
+            ],
+            "title": "Ack Type",
+            "type": "string"
+          },
+          "config": {
+            "description": "kafka的响应方式，honeypot表示是否报告蜜罐事件, scanner:是否报告扫描事件, portrait表示是否报告溯源事件,ping表示是否报告ping事件, arp表示是否报告ARP攻击, docker_escape表示是否报告docker逃逸事件,agent_status表示是否报告探针连接状态变化",
+            "items": {
+              "enum": [
+                "honeypot",
+                "scanner",
+                "portrait",
+                "ping",
+                "arp",
+                "docker_escape",
+                "agent_status"
+              ],
+              "type": "string"
+            },
+            "title": "Config",
+            "type": "array"
+          },
+          "encoding": {
+            "description": "kafka编码方式",
+            "enum": [
+              "GBK",
+              "UTF-8"
+            ],
+            "title": "Encoding",
+            "type": "string"
+          },
+          "host": {
+            "description": "kafka服务器地址",
+            "minLength": 1,
+            "title": "Host",
+            "type": "string"
+          },
+          "id": {
+            "description": "配置的ID",
+            "title": "Id",
+            "type": "integer"
+          },
+          "password": {
+            "default": "",
+            "description": "密码",
+            "title": "Password",
+            "type": "string"
+          },
+          "port": {
+            "description": "kafka服务器端口",
+            "maximum": 65535,
+            "minimum": 1,
+            "title": "Port",
+            "type": "integer"
+          },
+          "topic_name": {
+            "description": "topic名称",
+            "minLength": 1,
+            "title": "Topic Name",
+            "type": "string"
+          },
+          "username": {
+            "default": "",
+            "description": "用户名",
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic_name",
+          "host",
+          "port",
+          "encoding",
+          "ack_type",
+          "config"
+        ],
+        "title": "KafkaConfigDetail",
+        "type": "object"
+      },
+      "LdapConfigDetail": {
+        "properties": {
+          "admin_dn": {
+            "description": "ldap admin_dn",
+            "title": "Admin Dn",
+            "type": "string"
+          },
+          "admin_passwd": {
+            "description": "ldap authtype",
+            "title": "Admin Passwd",
+            "type": "string"
+          },
+          "base_dn": {
+            "description": "ldap base_dn",
+            "title": "Base Dn",
+            "type": "string"
+          },
+          "port": {
+            "description": "ldap 端口",
+            "title": "Port",
+            "type": "integer"
+          },
+          "server": {
+            "description": "ldap 服务器ip 域名",
+            "title": "Server",
+            "type": "string"
+          },
+          "user_key": {
+            "description": "ldap user key, like cn",
+            "title": "User Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "server",
+          "port",
+          "admin_dn",
+          "base_dn",
+          "admin_passwd",
+          "user_key"
+        ],
+        "title": "LdapConfigDetail",
+        "type": "object"
+      },
+      "LicenseInfo": {
+        "properties": {
+          "A1500": {
+            "description": "最大探针的数量，A1500型号",
+            "title": "A1500",
+            "type": "string"
+          },
+          "A2000": {
+            "description": "最大探针的数量，A2000型号",
+            "title": "A2000",
+            "type": "string"
+          },
+          "A3000": {
+            "description": "最大探针的数量，A3000型号",
+            "title": "A3000",
+            "type": "string"
+          },
+          "A4000": {
+            "description": "最大探针的数量，A4000型号",
+            "title": "A4000",
+            "type": "string"
+          },
+          "agent_overflow": {
+            "description": "探针超过的数量",
+            "title": "Agent Overflow",
+            "type": "integer"
+          },
+          "cannot_upgrade_after": {
+            "description": "可升级结束时间,-1 表示不限制",
+            "title": "Cannot Upgrade After",
+            "type": "integer"
+          },
+          "cannot_upgrade_before": {
+            "description": "可升级起始时间,-1 表示不限制",
+            "title": "Cannot Upgrade Before",
+            "type": "integer"
+          },
+          "client_name": {
+            "description": "客户名称",
+            "title": "Client Name",
+            "type": "string"
+          },
+          "licence_id": {
+            "description": "licence id",
+            "title": "Licence Id",
+            "type": "string"
+          },
+          "machine_ids": {
+            "description": "绑定的机机器码",
+            "items": {
+              "type": "string"
+            },
+            "title": "Machine Ids",
+            "type": "array"
+          },
+          "max_agent": {
+            "description": "最大探针的数量，A1000型号",
+            "title": "Max Agent",
+            "type": "string"
+          },
+          "max_host": {
+            "description": "最大的蜜罐数量",
+            "title": "Max Host",
+            "type": "string"
+          },
+          "max_ip_per_a15": {
+            "description": "A1500型号支持IP的数量",
+            "title": "Max Ip Per A15",
+            "type": "string"
+          },
+          "not_valid_after": {
+            "description": "证书的起始时间,-1 表示不限制",
+            "title": "Not Valid After",
+            "type": "integer"
+          },
+          "not_valid_before": {
+            "description": "证书的结束时间,-1 表示不限制",
+            "title": "Not Valid Before",
+            "type": "integer"
+          },
+          "platform_versions": {
+            "description": "版本license支持可升级的版本",
+            "items": {},
+            "title": "Platform Versions",
+            "type": "array"
+          },
+          "time_range": {
+            "description": "可使用时间范围",
+            "title": "Time Range",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent_overflow",
+          "client_name",
+          "licence_id",
+          "machine_ids",
+          "max_agent",
+          "max_host",
+          "max_ip_per_a15",
+          "A1500",
+          "A2000",
+          "A3000",
+          "A4000",
+          "not_valid_after",
+          "not_valid_before",
+          "time_range"
+        ],
+        "title": "LicenseInfo",
+        "type": "object"
+      },
+      "ListAlarmEvent": {
+        "description": "分页类响应的通用模式",
+        "properties": {
+          "data": {
+            "description": "实际返回的数据",
+            "items": {
+              "$ref": "#/components/schemas/AlarmEventDetail"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "handle_count": {
+            "description": "已经处置的数量",
+            "title": "Handle Count",
+            "type": "integer"
+          },
+          "total": {
+            "description": "满足条件的记录总数",
+            "minimum": 0,
+            "title": "Total",
+            "type": "integer"
+          },
+          "unhandle_count": {
+            "description": "未处置的数量",
+            "title": "Unhandle Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "data",
+          "unhandle_count",
+          "handle_count"
+        ],
+        "title": "ListAlarmEvent",
+        "type": "object"
+      },
+      "ListScriptSceneItem": {
+        "properties": {
+          "brief": {
+            "description": "场景简介",
+            "title": "Brief",
+            "type": "string"
+          },
+          "name": {
+            "description": "场景名称",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "brief"
+        ],
+        "title": "ListScriptSceneItem",
+        "type": "object"
+      },
+      "LogDetail": {
+        "properties": {
+          "alarm_policy": {
+            "description": "告警策略",
+            "title": "Alarm Policy",
+            "type": "string"
+          },
+          "content": {
+            "default": "",
+            "description": "审计日志内容",
+            "title": "Content",
+            "type": "string"
+          },
+          "create_time": {
+            "description": "创建时间",
+            "format": "date-time",
+            "title": "Create Time",
+            "type": "string"
+          },
+          "data_detail": {
+            "default": {},
+            "description": "数据详情，json格式",
+            "title": "Data Detail",
+            "type": "object"
+          },
+          "data_flag": {
+            "description": "是否为新数据，true为新数据，false为旧数据",
+            "title": "Data Flag",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "日志id",
+            "title": "Id",
+            "type": "string"
+          },
+          "ip": {
+            "default": "",
+            "description": "IP地址",
+            "title": "Ip",
+            "type": "string"
+          },
+          "node": {
+            "default": {},
+            "description": "子节点信息",
+            "title": "Node",
+            "type": "object"
+          },
+          "sent_alarm": {
+            "description": "是否发送告警",
+            "title": "Sent Alarm",
+            "type": "boolean"
+          },
+          "success": {
+            "description": "是否成功",
+            "title": "Success",
+            "type": "boolean"
+          },
+          "ua": {
+            "default": "",
+            "description": "用户代理",
+            "title": "Ua",
+            "type": "string"
+          },
+          "user": {
+            "description": "用户基本信息",
+            "title": "User",
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "create_time",
+          "sent_alarm",
+          "success"
+        ],
+        "title": "LogDetail",
+        "type": "object"
+      },
+      "ManageUserListDetail": {
+        "properties": {
+          "api_token": {
+            "description": "经过遮盖的api token，当前用户未生成token时为None",
+            "title": "Api Token",
+            "type": "string"
+          },
+          "create_time": {
+            "description": "用户创建时间",
+            "title": "Create Time",
+            "type": "string"
+          },
+          "date_joined": {
+            "description": "用户上次修改密码的时间",
+            "format": "date-time",
+            "title": "Date Joined",
+            "type": "string"
+          },
+          "email": {
+            "description": "用户名",
+            "title": "Email",
+            "type": "string"
+          },
+          "first_name": {
+            "description": "用户姓名",
+            "title": "First Name",
+            "type": "string"
+          },
+          "groups": {
+            "default": [],
+            "description": "组",
+            "items": {
+              "type": "string"
+            },
+            "title": "Groups",
+            "type": "array"
+          },
+          "guide": {
+            "description": "用户引导数据",
+            "items": {
+              "type": "string"
+            },
+            "title": "Guide",
+            "type": "array"
+          },
+          "id": {
+            "description": "用户ID",
+            "title": "Id",
+            "type": "integer"
+          },
+          "ip_policy": {
+            "description": "用户的IP策略",
+            "items": {
+              "type": "string"
+            },
+            "title": "Ip Policy",
+            "type": "array"
+          },
+          "ip_policy_mode": {
+            "description": "用户IP策略模式",
+            "enum": [
+              "allow",
+              "deny"
+            ],
+            "title": "Ip Policy Mode"
+          },
+          "isInitUser": {
+            "description": "用户是否是初始用户",
+            "title": "Isinituser",
+            "type": "boolean"
+          },
+          "is_active": {
+            "description": "用户是否激活",
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "is_deleted": {
+            "description": "用户是否删除",
+            "title": "Is Deleted",
+            "type": "boolean"
+          },
+          "is_locked": {
+            "default": "",
+            "description": "用户是否上锁",
+            "title": "Is Locked",
+            "type": "boolean"
+          },
+          "is_staff": {
+            "description": "用户是否是staff",
+            "title": "Is Staff",
+            "type": "boolean"
+          },
+          "is_superuser": {
+            "description": "用户是否是超级用户",
+            "title": "Is Superuser",
+            "type": "boolean"
+          },
+          "last_change_password": {
+            "description": "用户上次修改密码的时间",
+            "format": "date-time",
+            "title": "Last Change Password",
+            "type": "string"
+          },
+          "last_name": {
+            "description": "用户姓名",
+            "title": "Last Name",
+            "type": "string"
+          },
+          "ldap_search_base": {
+            "description": "ldap",
+            "title": "Ldap Search Base",
+            "type": "string"
+          },
+          "login_method": {
+            "description": "用户登录方式",
+            "enum": [
+              "cert",
+              "password",
+              "ldap",
+              "radius"
+            ],
+            "title": "Login Method"
+          },
+          "old_pwd": {
+            "default": [],
+            "description": "用户旧密码的Hash值",
+            "items": {
+              "type": "string"
+            },
+            "title": "Old Pwd",
+            "type": "array"
+          },
+          "permissions": {
+            "default": [],
+            "description": "权限",
+            "items": {
+              "type": "string"
+            },
+            "title": "Permissions",
+            "type": "array"
+          },
+          "role": {
+            "description": "用户角色",
+            "enum": [
+              "superAdmin",
+              "admin",
+              "auditor",
+              "tenant",
+              "log_observer"
+            ],
+            "title": "Role"
+          },
+          "session_timeout": {
+            "description": "用户会话过期时间",
+            "format": "time-delta",
+            "title": "Session Timeout",
+            "type": "number"
+          },
+          "totp_active": {
+            "description": "用户是否开启TOTP",
+            "title": "Totp Active",
+            "type": "boolean"
+          },
+          "user_permissions": {
+            "default": [],
+            "description": "用户权限",
+            "items": {
+              "type": "string"
+            },
+            "title": "User Permissions",
+            "type": "array"
+          },
+          "user_type": {
+            "description": "用户类型",
+            "enum": [
+              "normal",
+              "internal"
+            ],
+            "title": "User Type"
+          },
+          "username": {
+            "description": "用户名",
+            "title": "Username",
+            "type": "string"
+          },
+          "ws_token": {
+            "description": "websocket的token",
+            "title": "Ws Token",
+            "type": "string"
+          }
+        },
+        "title": "ManageUserListDetail",
+        "type": "object"
+      },
+      "MgDiskStatDetail": {
+        "properties": {
+          "free": {
+            "description": "磁盘剩余容量",
+            "title": "Free",
+            "type": "integer"
+          },
+          "used": {
+            "description": "磁盘已使用容量",
+            "title": "Used",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "used",
+          "free"
+        ],
+        "title": "MgDiskStatDetail",
+        "type": "object"
+      },
+      "MinimumRet": {
+        "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+        "properties": {
+          "success": {
+            "default": true,
+            "description": "请求成功",
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "title": "MinimumRet",
+        "type": "object"
+      },
+      "NodeAttackItemDetail": {
+        "properties": {
+          "arp_count": {
+            "description": "arp志数量",
+            "title": "Arp Count",
+            "type": "integer"
+          },
+          "honeypot_event_count": {
+            "description": "入侵日志总数",
+            "title": "Honeypot Event Count",
+            "type": "integer"
+          },
+          "honeypot_event_high_count": {
+            "description": "高危威胁入侵日志数量",
+            "title": "Honeypot Event High Count",
+            "type": "integer"
+          },
+          "honeypot_event_low_count": {
+            "description": "低危威胁入侵日志数量",
+            "title": "Honeypot Event Low Count",
+            "type": "integer"
+          },
+          "honeypot_event_mid_count": {
+            "description": "中危威胁入侵日志数量",
+            "title": "Honeypot Event Mid Count",
+            "type": "integer"
+          },
+          "honeypot_event_normal_count": {
+            "description": "无威胁入侵日志数量",
+            "title": "Honeypot Event Normal Count",
+            "type": "integer"
+          },
+          "is_deleted": {
+            "description": "节点是否被删除",
+            "title": "Is Deleted",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "被入侵的节点名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "ping_count": {
+            "description": "ping日志数量",
+            "title": "Ping Count",
+            "type": "integer"
+          },
+          "scanner_count": {
+            "description": "扫描日志数量",
+            "title": "Scanner Count",
+            "type": "integer"
+          },
+          "score": {
+            "description": "攻击程度",
+            "title": "Score",
+            "type": "integer"
+          },
+          "sn": {
+            "description": "被入侵的节点ID",
+            "title": "Sn",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sn",
+          "score",
+          "name",
+          "is_deleted",
+          "honeypot_event_count",
+          "honeypot_event_normal_count",
+          "honeypot_event_low_count",
+          "honeypot_event_mid_count",
+          "honeypot_event_high_count",
+          "scanner_count",
+          "ping_count",
+          "arp_count"
+        ],
+        "title": "NodeAttackItemDetail",
+        "type": "object"
+      },
+      "NodeInfoDetail": {
+        "properties": {
+          "active": {
+            "default": false,
+            "description": "数据同步状态",
+            "title": "Active",
+            "type": "boolean"
+          },
+          "agent_num_msg": {
+            "description": "探针数量",
+            "title": "Agent Num Msg",
+            "type": "string"
+          },
+          "api_port": {
+            "description": "api 端口",
+            "title": "Api Port",
+            "type": "integer"
+          },
+          "cpu_mem_info": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CpuMemStatStrDetail"
+              }
+            ],
+            "description": "子节点 内存/cpu使用量",
+            "title": "Cpu Mem Info"
+          },
+          "created": {
+            "default": true,
+            "description": "创建数据同步",
+            "title": "Created",
+            "type": "boolean"
+          },
+          "enable": {
+            "default": false,
+            "description": "启用数据同步",
+            "title": "Enable",
+            "type": "boolean"
+          },
+          "host": {
+            "description": "node 地址",
+            "title": "Host",
+            "type": "string"
+          },
+          "id": {
+            "description": "node id",
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "description": "node 名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "pg_port": {
+            "description": "pg 端口",
+            "title": "Pg Port",
+            "type": "integer"
+          },
+          "sn": {
+            "description": "node sn",
+            "title": "Sn",
+            "type": "string"
+          },
+          "status": {
+            "default": 0,
+            "description": "节点 状态",
+            "title": "Status",
+            "type": "integer"
+          },
+          "token": {
+            "description": "api token",
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "sn",
+          "name",
+          "pg_port",
+          "api_port",
+          "agent_num_msg"
+        ],
+        "title": "NodeInfoDetail",
+        "type": "object"
+      },
+      "OrderByInfo": {
+        "properties": {
+          "name": {
+            "description": "排序的字段名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "order": {
+            "description": "排序类型（升序或者降序）",
+            "title": "Order",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "order"
+        ],
+        "title": "OrderByInfo",
+        "type": "object"
+      },
+      "PackageAction": {
+        "properties": {
+          "display_name": {
+            "description": "升级动作中文名称",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "id": {
+            "description": "升级动作ID",
+            "title": "Id",
+            "type": "string"
+          },
+          "message": {
+            "description": "升级动作错误信息",
+            "title": "Message",
+            "type": "string"
+          },
+          "name": {
+            "description": "升级动作名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "state": {
+            "description": "当前下载状态(0表示等待执行状态，1表示运行中，2代表成功，3代表失败)",
+            "enum": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "title": "State",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "display_name",
+          "state",
+          "message"
+        ],
+        "title": "PackageAction",
+        "type": "object"
+      },
+      "PackageChunkBaseInfoRet": {
+        "properties": {
+          "expires": {
+            "description": "过期时间",
+            "title": "Expires",
+            "type": "string"
+          },
+          "md5": {
+            "description": "文件的md5",
+            "title": "Md5",
+            "type": "string"
+          },
+          "offset": {
+            "description": "文件的偏移量",
+            "title": "Offset",
+            "type": "integer"
+          },
+          "upload_id": {
+            "description": "文件上传任务id",
+            "title": "Upload Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "upload_id",
+          "offset",
+          "md5",
+          "expires"
+        ],
+        "title": "PackageChunkBaseInfoRet",
+        "type": "object"
+      },
+      "PackageChunkedRet": {
+        "properties": {
+          "files": {
+            "description": "文件列表",
+            "items": {
+              "$ref": "#/components/schemas/PackageChunkBaseInfoRet"
+            },
+            "title": "Files",
+            "type": "array"
+          }
+        },
+        "required": [
+          "files"
+        ],
+        "title": "PackageChunkedRet",
+        "type": "object"
+      },
+      "PackageCurrentInfoRet": {
+        "properties": {
+          "agent": {
+            "description": "探针的版本",
+            "title": "Agent",
+            "type": "string"
+          },
+          "agent_update": {
+            "default": {},
+            "description": "agent升级信息",
+            "title": "Agent Update",
+            "type": "object"
+          },
+          "honeypot": {
+            "description": "蜜罐的版本",
+            "title": "Honeypot",
+            "type": "string"
+          },
+          "honeypot_update": {
+            "default": {},
+            "description": "蜜罐升级信息",
+            "title": "Honeypot Update",
+            "type": "object"
+          },
+          "manager": {
+            "description": "系统版本",
+            "title": "Manager",
+            "type": "string"
+          },
+          "patch": {
+            "description": "升级包的版本",
+            "title": "Patch",
+            "type": "string"
+          },
+          "patch_update": {
+            "default": {},
+            "description": "补丁包升级信息",
+            "title": "Patch Update",
+            "type": "object"
+          }
+        },
+        "title": "PackageCurrentInfoRet",
+        "type": "object"
+      },
+      "PackageInfoRet": {
+        "properties": {
+          "chunk": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PackageChunkedRet"
+              }
+            ],
+            "description": "chunk包信息",
+            "title": "Chunk"
+          },
+          "current": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PackageCurrentInfoRet"
+              }
+            ],
+            "description": "当前升级包信息",
+            "title": "Current"
+          },
+          "wait": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PackageWaitInfoRet"
+              }
+            ],
+            "description": "带应用升级包信息",
+            "title": "Wait"
+          }
+        },
+        "required": [
+          "current",
+          "wait",
+          "chunk"
+        ],
+        "title": "PackageInfoRet",
+        "type": "object"
+      },
+      "PackageWaitBaseInfoRet": {
+        "properties": {
+          "comment": {
+            "description": "升级失败原因备注",
+            "title": "Comment",
+            "type": "string"
+          },
+          "description": {
+            "description": "描述信息",
+            "title": "Description",
+            "type": "string"
+          },
+          "downloaded_size": {
+            "description": "已经下载的文件大小",
+            "title": "Downloaded Size",
+            "type": "integer"
+          },
+          "filename": {
+            "description": "文件名",
+            "title": "Filename",
+            "type": "string"
+          },
+          "id": {
+            "description": "文件id",
+            "title": "Id",
+            "type": "string"
+          },
+          "is_upstream": {
+            "description": "是否来自于统一升级平台",
+            "title": "Is Upstream",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "升级包名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "need_version": {
+            "description": "适用版本",
+            "title": "Need Version",
+            "type": "string"
+          },
+          "size": {
+            "description": "文件大小",
+            "title": "Size",
+            "type": "integer"
+          },
+          "status": {
+            "description": "升级状态, 0表示未知，1表示运行中，2表示成功，3表示失败，4表示已取消，5表示下载初始状态，6表示下载中，7表示下载失败，8表示下载成功",
+            "enum": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ],
+            "title": "Status",
+            "type": "integer"
+          },
+          "type": {
+            "description": "文件类型",
+            "enum": [
+              "",
+              "patch",
+              "manager",
+              "honeypot",
+              "agent"
+            ],
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "filename",
+          "type",
+          "size",
+          "downloaded_size",
+          "status",
+          "comment",
+          "description",
+          "need_version",
+          "is_upstream"
+        ],
+        "title": "PackageWaitBaseInfoRet",
+        "type": "object"
+      },
+      "PackageWaitInfoRet": {
+        "properties": {
+          "files": {
+            "description": "文件列表",
+            "items": {
+              "$ref": "#/components/schemas/PackageWaitBaseInfoRet"
+            },
+            "title": "Files",
+            "type": "array"
+          }
+        },
+        "required": [
+          "files"
+        ],
+        "title": "PackageWaitInfoRet",
+        "type": "object"
+      },
+      "PageingRetBase_ItemType_": {
+        "description": "Abstract base class for generic types.\n\nA generic type is typically declared by inheriting from\nthis class parameterized with one or more type variables.\nFor example, a generic mapping type might be defined as::\n\n  class Mapping(Generic[KT, VT]):\n      def __getitem__(self, key: KT) -> VT:\n          ...\n      # Etc.\n\nThis class can then be used as follows::\n\n  def lookup_name(mapping: Mapping[KT, VT], key: KT, default: VT) -> VT:\n      try:\n          return mapping[key]\n      except KeyError:\n          return default",
+        "properties": {
+          "data": {
+            "description": "实际返回的数据",
+            "items": {},
+            "title": "Data",
+            "type": "array"
+          },
+          "total": {
+            "description": "满足条件的记录总数",
+            "minimum": 0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "data"
+        ],
+        "title": "PageingRetBase[ItemType]",
+        "type": "object"
+      },
+      "Pair_str__int_": {
+        "description": "一对键值\n\nJSON中没有原生的Dict类型，虽然可以通过object代替，但一般被认为是一种不好的模式。\n需要与前端交换若干键值对信息时，推荐的类型是List[Pair[Key, Value]]",
+        "properties": {
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "title": "Pair[str, int]",
+        "type": "object"
+      },
+      "PartitionConfigDetail": {
+        "properties": {
+          "attach_tablespace": {
+            "description": "正常表空间",
+            "title": "Attach Tablespace",
+            "type": "string"
+          },
+          "detach_tablespace": {
+            "description": "归档表空间",
+            "title": "Detach Tablespace",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "interval": {
+            "description": "归档间隔",
+            "exclusiveMinimum": true,
+            "minimum": 0,
+            "title": "Interval",
+            "type": "integer"
+          },
+          "logs": {
+            "description": "分区表信息",
+            "items": {
+              "$ref": "#/components/schemas/PartitionLogInfo"
+            },
+            "title": "Logs",
+            "type": "array"
+          },
+          "model_label": {
+            "description": "表名称",
+            "title": "Model Label",
+            "type": "string"
+          },
+          "period": {
+            "description": "分表周期",
+            "title": "Period",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "logs",
+          "model_label",
+          "period"
+        ],
+        "title": "PartitionConfigDetail",
+        "type": "object"
+      },
+      "PartitionLogInfo": {
+        "properties": {
+          "count": {
+            "description": "不知道是啥",
+            "title": "Count",
+            "type": "integer"
+          },
+          "detach_time": {
+            "description": "归档时间",
+            "format": "date-time",
+            "title": "Detach Time",
+            "type": "string"
+          },
+          "end": {
+            "description": "结束时间",
+            "format": "date-time",
+            "title": "End",
+            "type": "string"
+          },
+          "id": {
+            "description": "分区表id",
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_attached": {
+            "default": true,
+            "description": "是否未归档",
+            "title": "Is Attached",
+            "type": "boolean"
+          },
+          "pg_total_relation_size": {
+            "description": "分区表总大小",
+            "title": "Pg Total Relation Size",
+            "type": "integer"
+          },
+          "start": {
+            "description": "结束时间",
+            "format": "date-time",
+            "title": "Start",
+            "type": "string"
+          },
+          "table_name": {
+            "description": "分区表名称",
+            "title": "Table Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "table_name",
+          "start",
+          "end",
+          "pg_total_relation_size",
+          "count"
+        ],
+        "title": "PartitionLogInfo",
+        "type": "object"
+      },
+      "PortRange": {
+        "properties": {
+          "end_port": {
+            "description": "结束端口",
+            "title": "End Port",
+            "type": "integer"
+          },
+          "start_port": {
+            "description": "起始端口",
+            "title": "Start Port",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "start_port",
+          "end_port"
+        ],
+        "title": "PortRange",
+        "type": "object"
+      },
+      "PortmapData": {
+        "properties": {
+          "agent_sn": {
+            "default": "",
+            "description": "探针ID",
+            "title": "Agent Sn",
+            "type": "string"
+          },
+          "bind_port": {
+            "description": "是否绑定端口",
+            "title": "Bind Port",
+            "type": "boolean"
+          },
+          "end_port": {
+            "description": "结束端口",
+            "title": "End Port",
+            "type": "string"
+          },
+          "err": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PortmapDataError"
+              }
+            ],
+            "description": "错误信息",
+            "title": "Err"
+          },
+          "fixed": {
+            "description": "是否是固定",
+            "title": "Fixed",
+            "type": "boolean"
+          },
+          "group_id": {
+            "description": "portmap对应的分组id",
+            "title": "Group Id",
+            "type": "string"
+          },
+          "honeynet": {
+            "description": "蜜网ID",
+            "title": "Honeynet",
+            "type": "string"
+          },
+          "honeypot": {
+            "description": "蜜罐ID",
+            "title": "Honeypot",
+            "type": "string"
+          },
+          "honeypot_display_name": {
+            "default": "",
+            "description": "蜜罐展示名称",
+            "title": "Honeypot Display Name",
+            "type": "string"
+          },
+          "honeypot_image": {
+            "default": "",
+            "description": "蜜罐镜像，比如wiki",
+            "title": "Honeypot Image",
+            "type": "string"
+          },
+          "honeypot_preset": {
+            "title": "Honeypot Preset",
+            "type": "string"
+          },
+          "honeypot_preset_dict": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HoneypotPresetBaseArg"
+              }
+            ],
+            "description": "模版相关信息",
+            "title": "Honeypot Preset Dict"
+          },
+          "id": {
+            "description": "portmap id",
+            "title": "Id",
+            "type": "string"
+          },
+          "image_display_name": {
+            "default": "",
+            "description": "镜像展示名字",
+            "title": "Image Display Name",
+            "type": "string"
+          },
+          "image_version": {
+            "default": "unknown",
+            "description": "镜像版本",
+            "title": "Image Version",
+            "type": "string"
+          },
+          "proto": {
+            "description": "监听协议",
+            "title": "Proto",
+            "type": "string"
+          },
+          "save_pcap": {
+            "description": "是否保存pcap",
+            "title": "Save Pcap",
+            "type": "boolean"
+          },
+          "scan_det": {
+            "description": "是否是端口扫描",
+            "title": "Scan Det",
+            "type": "boolean"
+          },
+          "script_id": {
+            "default": "",
+            "description": "蜜网剧本ID",
+            "title": "Script Id",
+            "type": "string"
+          },
+          "service_ips": {
+            "default": [],
+            "description": "监听的服务ip列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Service Ips",
+            "type": "array"
+          },
+          "start_port": {
+            "description": "起始端口",
+            "title": "Start Port",
+            "type": "string"
+          },
+          "status": {
+            "description": "状态",
+            "title": "Status",
+            "type": "integer"
+          },
+          "target_port": {
+            "description": "蜜罐实际访问的端口",
+            "title": "Target Port",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "start_port",
+          "end_port",
+          "proto"
+        ],
+        "title": "PortmapData",
+        "type": "object"
+      },
+      "PortmapDataError": {
+        "properties": {
+          "err": {
+            "description": "错误key",
+            "title": "Err",
+            "type": "string"
+          },
+          "msg": {
+            "description": "错误内容",
+            "title": "Msg",
+            "type": "string"
+          },
+          "role": {
+            "description": "角色",
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "title": "PortmapDataError",
+        "type": "object"
+      },
+      "Portmaps": {
+        "properties": {
+          "agent_sn": {
+            "description": "探针ID",
+            "title": "Agent Sn",
+            "type": "string"
+          },
+          "datas": {
+            "description": "需要更新的服务列表",
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/PortmapData"
+              },
+              "type": "array"
+            },
+            "title": "Datas",
+            "type": "array"
+          },
+          "node_sn": {
+            "description": "节点的sn",
+            "title": "Node Sn",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent_sn",
+          "datas"
+        ],
+        "title": "Portmaps",
+        "type": "object"
+      },
+      "PortraitAttackerInfo": {
+        "properties": {
+          "details": {
+            "description": "攻击者信息",
+            "items": {
+              "$ref": "#/components/schemas/PortraitDetails"
+            },
+            "title": "Details",
+            "type": "array"
+          },
+          "id": {
+            "description": "攻击者uuid",
+            "title": "Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "PortraitAttackerInfo",
+        "type": "object"
+      },
+      "PortraitDetailV1": {
+        "properties": {
+          "attack_info": {
+            "items": {},
+            "title": "Attack Info",
+            "type": "array"
+          },
+          "browser": {
+            "items": {
+              "type": "object"
+            },
+            "title": "Browser",
+            "type": "array"
+          },
+          "browser_icon": {
+            "default": [],
+            "description": "浏览器日志icon",
+            "items": {},
+            "title": "Browser Icon",
+            "type": "array"
+          },
+          "connids": {
+            "items": {},
+            "title": "Connids",
+            "type": "array"
+          },
+          "event_count": {
+            "minimum": 0,
+            "title": "Event Count",
+            "type": "integer"
+          },
+          "honeypots": {
+            "items": {
+              "type": "object"
+            },
+            "title": "Honeypots",
+            "type": "array"
+          },
+          "host": {
+            "items": {
+              "type": "object"
+            },
+            "title": "Host",
+            "type": "array"
+          },
+          "icon": {
+            "default": [],
+            "description": "社交溯源日志icon",
+            "items": {},
+            "title": "Icon",
+            "type": "array"
+          },
+          "last_attack_time": {
+            "format": "date-time",
+            "title": "Last Attack Time",
+            "type": "string"
+          },
+          "network": {
+            "title": "Network",
+            "type": "object"
+          },
+          "node": {
+            "title": "Node",
+            "type": "string"
+          },
+          "numid": {
+            "title": "Numid",
+            "type": "string"
+          },
+          "os_icon": {
+            "default": [],
+            "description": "操作系统日志icon",
+            "items": {},
+            "title": "Os Icon",
+            "type": "array"
+          },
+          "social": {
+            "items": {
+              "type": "object"
+            },
+            "title": "Social",
+            "type": "array"
+          },
+          "tagid": {
+            "title": "Tagid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "numid",
+          "tagid",
+          "node",
+          "host",
+          "network",
+          "social",
+          "browser",
+          "last_attack_time",
+          "event_count",
+          "connids",
+          "honeypots",
+          "attack_info"
+        ],
+        "title": "PortraitDetailV1",
+        "type": "object"
+      },
+      "PortraitDetails": {
+        "properties": {
+          "children": {
+            "description": "子段落信息",
+            "items": {
+              "$ref": "#/components/schemas/PortraitDetails"
+            },
+            "title": "Children",
+            "type": "array"
+          },
+          "list": {
+            "description": "列表信息",
+            "items": {
+              "$ref": "#/components/schemas/PortraitListDetails"
+            },
+            "title": "List",
+            "type": "array"
+          },
+          "order": {
+            "description": "排序信息",
+            "items": {
+              "type": "string"
+            },
+            "title": "Order",
+            "type": "array"
+          },
+          "table": {
+            "description": "表格信息",
+            "items": {
+              "$ref": "#/components/schemas/PortraitTableDetails"
+            },
+            "title": "Table",
+            "type": "array"
+          },
+          "title": {
+            "description": "标题信息",
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "order"
+        ],
+        "title": "PortraitDetails",
+        "type": "object"
+      },
+      "PortraitListDetails": {
+        "properties": {
+          "key": {
+            "description": "列表key",
+            "title": "Key",
+            "type": "string"
+          },
+          "value": {
+            "description": "列表值",
+            "items": {
+              "$ref": "#/components/schemas/PortraitSubListItem"
+            },
+            "title": "Value",
+            "type": "array"
+          }
+        },
+        "title": "PortraitListDetails",
+        "type": "object"
+      },
+      "PortraitReportInfo": {
+        "properties": {
+          "info": {
+            "description": "溯源信息",
+            "items": {
+              "$ref": "#/components/schemas/PortraitAttackerInfo"
+            },
+            "title": "Info",
+            "type": "array"
+          },
+          "time": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PortraitReportTimeInfo"
+              }
+            ],
+            "description": "筛选时间",
+            "title": "Time"
+          },
+          "version": {
+            "description": "版本号",
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version"
+        ],
+        "title": "PortraitReportInfo",
+        "type": "object"
+      },
+      "PortraitReportTimeInfo": {
+        "properties": {
+          "end": {
+            "description": "筛选结束时间",
+            "title": "End",
+            "type": "string"
+          },
+          "start": {
+            "description": "筛选起始时间",
+            "title": "Start",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start",
+          "end"
+        ],
+        "title": "PortraitReportTimeInfo",
+        "type": "object"
+      },
+      "PortraitSubListItem": {
+        "properties": {
+          "label": {
+            "description": "列表具体项的标签",
+            "title": "Label",
+            "type": "string"
+          },
+          "value": {
+            "description": "列表具体项的值",
+            "title": "Value",
+            "type": "string"
+          }
+        },
+        "title": "PortraitSubListItem",
+        "type": "object"
+      },
+      "PortraitTableDetails": {
+        "properties": {
+          "header": {
+            "description": "表格头部信息",
+            "items": {
+              "type": "string"
+            },
+            "title": "Header",
+            "type": "array"
+          },
+          "key": {
+            "description": "表格key",
+            "title": "Key",
+            "type": "string"
+          },
+          "value": {
+            "description": "表格中具体的值",
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "title": "Value",
+            "type": "array"
+          }
+        },
+        "title": "PortraitTableDetails",
+        "type": "object"
+      },
+      "PresetData": {
+        "properties": {
+          "preset_id": {
+            "default": "",
+            "description": "模版ID",
+            "title": "Preset Id",
+            "type": "string"
+          }
+        },
+        "title": "PresetData",
+        "type": "object"
+      },
+      "ProtoCfg": {
+        "properties": {
+          "enable_token": {
+            "description": "是否启用token",
+            "title": "Enable Token",
+            "type": "boolean"
+          },
+          "proto_mode": {
+            "default": "proxyproto",
+            "description": "协议类型，proxyproto, default",
+            "enum": [
+              "proxyproto",
+              "default"
+            ],
+            "title": "Proto Mode",
+            "type": "string"
+          },
+          "proto_token": {
+            "title": "Proto Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "enable_token"
+        ],
+        "title": "ProtoCfg",
+        "type": "object"
+      },
+      "RadiusConfigDetail": {
+        "properties": {
+          "auth_type": {
+            "description": "radius authtype",
+            "title": "Auth Type",
+            "type": "string"
+          },
+          "port": {
+            "description": "radius 端口",
+            "title": "Port",
+            "type": "integer"
+          },
+          "secret": {
+            "description": "radius secret",
+            "title": "Secret",
+            "type": "string"
+          },
+          "server": {
+            "description": "radius 服务器ip 域名",
+            "title": "Server",
+            "type": "string"
+          }
+        },
+        "required": [
+          "server",
+          "port",
+          "secret",
+          "auth_type"
+        ],
+        "title": "RadiusConfigDetail",
+        "type": "object"
+      },
+      "ReportConfigDetail": {
+        "properties": {
+          "cron_date": {
+            "default": 0,
+            "description": "周期开始时间",
+            "title": "Cron Date",
+            "type": "integer"
+          },
+          "period": {
+            "description": "生成报告周期",
+            "title": "Period",
+            "type": "string"
+          },
+          "report_type": {
+            "default": [],
+            "description": "报告类型",
+            "items": {
+              "type": "string"
+            },
+            "title": "Report Type",
+            "type": "array"
+          },
+          "status": {
+            "description": "自动生成报告是否开启",
+            "title": "Status",
+            "type": "boolean"
+          },
+          "tenant_ids": {
+            "default": [],
+            "description": "租户id列表",
+            "items": {
+              "type": "integer"
+            },
+            "title": "Tenant Ids",
+            "type": "array"
+          }
+        },
+        "title": "ReportConfigDetail",
+        "type": "object"
+      },
+      "SMTPServerDetail": {
+        "properties": {
+          "address": {
+            "description": "发件邮箱地址",
+            "title": "Address",
+            "type": "string"
+          },
+          "display_name": {
+            "description": "smtp模版名称",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "email": {
+            "description": "发件邮箱账号",
+            "title": "Email",
+            "type": "string"
+          },
+          "event_last_send": {
+            "description": "最后一次发送事件的时间",
+            "format": "date-time",
+            "title": "Event Last Send",
+            "type": "string"
+          },
+          "id": {
+            "description": "smtp配置模版id",
+            "title": "Id",
+            "type": "integer"
+          },
+          "monthly_last_send": {
+            "description": "每月的最后一次发送时间",
+            "format": "date-time",
+            "title": "Monthly Last Send",
+            "type": "string"
+          },
+          "no_key": {
+            "default": false,
+            "description": "是否设置密码",
+            "title": "No Key",
+            "type": "boolean"
+          },
+          "password": {
+            "default": "",
+            "description": "发件邮箱密码",
+            "title": "Password",
+            "type": "string"
+          },
+          "port": {
+            "description": "SMTP 服务器端口号",
+            "title": "Port",
+            "type": "integer"
+          },
+          "server": {
+            "description": "SMTP 服务器地址",
+            "title": "Server",
+            "type": "string"
+          },
+          "type": {
+            "description": "传输加密方式",
+            "title": "Type",
+            "type": "string"
+          },
+          "username": {
+            "description": "smtp模版所属用户",
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "server",
+          "port",
+          "email"
+        ],
+        "title": "SMTPServerDetail",
+        "type": "object"
+      },
+      "SNMPServiceConfig": {
+        "properties": {
+          "allow_oids": {
+            "default": [],
+            "description": "允许访问的oid",
+            "items": {
+              "type": "string"
+            },
+            "title": "Allow Oids",
+            "type": "array"
+          },
+          "allowed_ips": {
+            "default": [],
+            "description": "允许访问的ip, 这个字段暂时没用",
+            "items": {
+              "type": "string"
+            },
+            "title": "Allowed Ips",
+            "type": "array"
+          },
+          "port": {
+            "default": 161,
+            "description": "snmp端口",
+            "title": "Port",
+            "type": "integer"
+          },
+          "v1v2c_auth_method": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SNMPV1V2CAuthMethod"
+              }
+            ],
+            "description": "v1v2登陆设置",
+            "title": "V1V2C Auth Method"
+          },
+          "v3_auth_method": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SNMPV3AuthMethod"
+              }
+            ],
+            "description": "v3登陆设置",
+            "title": "V3 Auth Method"
+          }
+        },
+        "title": "SNMPServiceConfig",
+        "type": "object"
+      },
+      "SNMPV1V2CAuthMethod": {
+        "properties": {
+          "community": {
+            "default": "",
+            "description": "组织",
+            "title": "Community",
+            "type": "string"
+          },
+          "trap_method": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SNMPV1V2CTrapMethod"
+              }
+            ],
+            "description": "v1v2 trap方法",
+            "title": "Trap Method"
+          },
+          "v1_disabled": {
+            "default": true,
+            "description": "禁用v1",
+            "title": "V1 Disabled",
+            "type": "boolean"
+          }
+        },
+        "title": "SNMPV1V2CAuthMethod",
+        "type": "object"
+      },
+      "SNMPV1V2CTrapMethod": {
+        "properties": {
+          "allow_monitors": {
+            "default": [],
+            "description": "允许的监控列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Allow Monitors",
+            "type": "array"
+          },
+          "encryption_method": {
+            "default": 0,
+            "description": "加密方法, NONE: 0, AES: 1, DES: 2",
+            "enum": [
+              0,
+              1,
+              2
+            ],
+            "title": "Encryption Method",
+            "type": "integer"
+          },
+          "hash_method": {
+            "default": 0,
+            "description": "hash方法, MD5: 0, SHA: 1",
+            "enum": [
+              0,
+              1
+            ],
+            "title": "Hash Method",
+            "type": "integer"
+          },
+          "password": {
+            "default": "",
+            "description": "密码",
+            "title": "Password",
+            "type": "string"
+          },
+          "trap_addr": {
+            "default": "",
+            "description": "trap地址",
+            "title": "Trap Addr",
+            "type": "string"
+          },
+          "username": {
+            "default": "",
+            "description": "用户名",
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "title": "SNMPV1V2CTrapMethod",
+        "type": "object"
+      },
+      "SNMPV3AuthMethod": {
+        "properties": {
+          "encryption_method": {
+            "default": 0,
+            "description": "加密方法, NONE: 0, AES: 1, DES: 2",
+            "enum": [
+              0,
+              1,
+              2
+            ],
+            "title": "Encryption Method",
+            "type": "integer"
+          },
+          "hash_method": {
+            "default": 0,
+            "description": "hash方法, MD5: 0, SHA: 1",
+            "enum": [
+              0,
+              1
+            ],
+            "title": "Hash Method",
+            "type": "integer"
+          },
+          "password": {
+            "default": "",
+            "description": "密码",
+            "title": "Password",
+            "type": "string"
+          },
+          "trap_method": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SNMPV3TrapMethod"
+              }
+            ],
+            "description": "v3 trap方法",
+            "title": "Trap Method"
+          },
+          "username": {
+            "default": "",
+            "description": "用户名",
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "title": "SNMPV3AuthMethod",
+        "type": "object"
+      },
+      "SNMPV3TrapMethod": {
+        "properties": {
+          "allow_monitors": {
+            "default": [],
+            "description": "允许的监控列表, 'defaultMonitors yes', 'linkUpDownNotifications yes'",
+            "items": {
+              "type": "string"
+            },
+            "title": "Allow Monitors",
+            "type": "array"
+          },
+          "trap_addr": {
+            "default": "",
+            "description": "trap地址",
+            "title": "Trap Addr",
+            "type": "string"
+          }
+        },
+        "title": "SNMPV3TrapMethod",
+        "type": "object"
+      },
+      "ScanPortmaps": {
+        "properties": {
+          "port_range": {
+            "description": "端口范围列表",
+            "items": {
+              "$ref": "#/components/schemas/PortRange"
+            },
+            "title": "Port Range",
+            "type": "array"
+          },
+          "proto": {
+            "description": "协议",
+            "title": "Proto",
+            "type": "string"
+          }
+        },
+        "required": [
+          "proto",
+          "port_range"
+        ],
+        "title": "ScanPortmaps",
+        "type": "object"
+      },
+      "ScannerEventMsg": {
+        "properties": {
+          "agent_display_name": {
+            "description": "探针的人类可读名称",
+            "title": "Agent Display Name",
+            "type": "string"
+          },
+          "agent_id": {
+            "description": "探针的ID",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "agent_ip": {
+            "description": "探针的IP地址",
+            "format": "ipvanyaddress",
+            "title": "Agent Ip",
+            "type": "string"
+          },
+          "agent_is_deleted": {
+            "description": "探针是否被删除",
+            "title": "Agent Is Deleted",
+            "type": "boolean"
+          },
+          "business_group": {
+            "default": "",
+            "description": "探针所属业务组信息",
+            "title": "Business Group",
+            "type": "string"
+          },
+          "dest_ip": {
+            "description": "受到扫描的IP地址",
+            "format": "ipvanyaddress",
+            "title": "Dest Ip",
+            "type": "string"
+          },
+          "dest_ports_display": {
+            "description": "目标端口列表的人类可读形式，形如“100-200,22”或“100-200,22,443等54个端口”",
+            "title": "Dest Ports Display",
+            "type": "string"
+          },
+          "end_time": {
+            "description": "扫描开始时间",
+            "format": "date-time",
+            "title": "End Time",
+            "type": "string"
+          },
+          "events": {
+            "description": "相关事件列表",
+            "items": {
+              "$ref": "#/components/schemas/SubScanEvent"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "id": {
+            "description": "扫描事件ID",
+            "title": "Id",
+            "type": "string"
+          },
+          "node": {
+            "default": {},
+            "description": "节点信息",
+            "title": "Node",
+            "type": "object"
+          },
+          "proto": {
+            "description": "扫描协议",
+            "title": "Proto",
+            "type": "string"
+          },
+          "scan_types": {
+            "description": "相关事件列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Scan Types",
+            "type": "array"
+          },
+          "src_ip": {
+            "description": "发起扫描的IP地址",
+            "format": "ipvanyaddress",
+            "title": "Src Ip",
+            "type": "string"
+          },
+          "src_ip_location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeoLocationDetail"
+              }
+            ],
+            "description": "发起连接的IP的归属地信息",
+            "title": "Src Ip Location"
+          },
+          "src_mac": {
+            "description": "发起扫描的MAC地址",
+            "title": "Src Mac",
+            "type": "string"
+          },
+          "src_port": {
+            "description": "发起扫描的端口",
+            "title": "Src Port",
+            "type": "string"
+          },
+          "start_time": {
+            "description": "扫描开始时间",
+            "format": "date-time",
+            "title": "Start Time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "proto",
+          "start_time",
+          "agent_display_name",
+          "dest_ip",
+          "dest_ports_display",
+          "src_ip"
+        ],
+        "title": "ScannerEventMsg",
+        "type": "object"
+      },
+      "SetPartitionlogRetData": {
+        "properties": {
+          "skiped": {
+            "default": [],
+            "description": "跳过的 log id list",
+            "items": {
+              "type": "integer"
+            },
+            "title": "Skiped",
+            "type": "array"
+          }
+        },
+        "title": "SetPartitionlogRetData",
+        "type": "object"
+      },
+      "SetXffArg": {
+        "properties": {
+          "xff_enable": {
+            "description": "是否启用",
+            "title": "Xff Enable",
+            "type": "boolean"
+          },
+          "xff_index": {
+            "description": "第几个IP（暂时不做）",
+            "title": "Xff Index",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "xff_enable"
+        ],
+        "title": "SetXffArg",
+        "type": "object"
+      },
+      "SmsAlarmDetail": {
+        "properties": {
+          "display_name": {
+            "description": "webhook模版名称",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "encode": {
+            "description": "编码格式",
+            "title": "Encode",
+            "type": "string"
+          },
+          "id": {
+            "description": "webhook配置的id",
+            "title": "Id",
+            "type": "string"
+          },
+          "message": {
+            "description": "告警消息",
+            "title": "Message",
+            "type": "string"
+          },
+          "param_type": {
+            "description": "请求参数类型, json 或 string，xml",
+            "enum": [
+              "string",
+              "json",
+              "xml"
+            ],
+            "title": "Param Type",
+            "type": "string"
+          },
+          "url": {
+            "description": "请求的url",
+            "title": "Url",
+            "type": "string"
+          },
+          "username": {
+            "description": "模版所属用户",
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "param_type",
+          "message"
+        ],
+        "title": "SmsAlarmDetail",
+        "type": "object"
+      },
+      "SubScanEvent": {
+        "properties": {
+          "dest_port": {
+            "description": "目标端口列表",
+            "title": "Dest Port",
+            "type": "string"
+          },
+          "dumb_captures": {
+            "default": [],
+            "description": "扫描报文",
+            "items": {
+              "$ref": "#/components/schemas/DumbCapture"
+            },
+            "title": "Dumb Captures",
+            "type": "array"
+          },
+          "end_time": {
+            "description": "扫描结束时间",
+            "format": "date-time",
+            "title": "End Time",
+            "type": "string"
+          },
+          "scan_type": {
+            "description": "扫描方式列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Scan Type",
+            "type": "array"
+          },
+          "start_time": {
+            "description": "扫描开始时间",
+            "format": "date-time",
+            "title": "Start Time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start_time",
+          "end_time",
+          "dest_port",
+          "scan_type"
+        ],
+        "title": "SubScanEvent",
+        "type": "object"
+      },
+      "SyslogConfigDetail": {
+        "properties": {
+          "agent_status": {
+            "description": "是否报告探针连接状态变化",
+            "title": "Agent Status",
+            "type": "boolean"
+          },
+          "arp_event": {
+            "description": "是否报告ARP攻击",
+            "title": "Arp Event",
+            "type": "boolean"
+          },
+          "docker_escape": {
+            "description": "是否报告docker逃逸事件",
+            "title": "Docker Escape",
+            "type": "boolean"
+          },
+          "encoding": {
+            "description": "syslog编码方式",
+            "enum": [
+              "Unicode",
+              "UTF-8"
+            ],
+            "title": "Encoding"
+          },
+          "format": {
+            "default": "rfc5424",
+            "description": "syslog格式",
+            "enum": [
+              "rfc3164",
+              "rfc5424"
+            ],
+            "title": "Format"
+          },
+          "honeypot_event": {
+            "description": "是否报告蜜罐事件",
+            "title": "Honeypot Event",
+            "type": "boolean"
+          },
+          "host": {
+            "description": "syslog服务器地址",
+            "minLength": 1,
+            "title": "Host",
+            "type": "string"
+          },
+          "id": {
+            "description": "syslog配置的ID",
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_base64_decode": {
+            "default": false,
+            "description": "是否base64解码日志中的header",
+            "title": "Is Base64 Decode",
+            "type": "boolean"
+          },
+          "ping_event": {
+            "description": "是否报告ping事件",
+            "title": "Ping Event",
+            "type": "boolean"
+          },
+          "port": {
+            "description": "syslog服务器端口",
+            "maximum": 65535,
+            "minimum": 1,
+            "title": "Port",
+            "type": "integer"
+          },
+          "portrait_event": {
+            "description": "是否报告溯源事件",
+            "title": "Portrait Event",
+            "type": "boolean"
+          },
+          "scanner_event": {
+            "description": "是否报告扫描事件",
+            "title": "Scanner Event",
+            "type": "boolean"
+          },
+          "socket_type": {
+            "description": "syslog的网络传输方式",
+            "enum": [
+              "TCP",
+              "UDP"
+            ],
+            "title": "Socket Type"
+          },
+          "time_diff": {
+            "default": 0,
+            "description": "自定义加减整数时间差",
+            "title": "Time Diff",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "host",
+          "port",
+          "encoding",
+          "socket_type",
+          "honeypot_event",
+          "scanner_event",
+          "portrait_event",
+          "ping_event",
+          "arp_event",
+          "docker_escape",
+          "agent_status"
+        ],
+        "title": "SyslogConfigDetail",
+        "type": "object"
+      },
+      "SystemAlarmDetail": {
+        "properties": {
+          "agent_id": {
+            "default": "",
+            "description": "探针id",
+            "format": "uuid",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "alarm_type": {
+            "description": "类型有:cpu,memory,disk,agent",
+            "enum": [
+              "cpu",
+              "memory",
+              "disk",
+              "agent",
+              "reset_honeypot",
+              "restart_honeypot"
+            ],
+            "title": "Alarm Type",
+            "type": "string"
+          },
+          "description": {
+            "description": "告警信息描述",
+            "title": "Description",
+            "type": "string"
+          },
+          "id": {
+            "default": "",
+            "description": "系统告警信息的唯一标识",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "alarm_type",
+          "description"
+        ],
+        "title": "SystemAlarmDetail",
+        "type": "object"
+      },
+      "SystemLogDetail": {
+        "properties": {
+          "content": {
+            "description": "系统日志的内容",
+            "title": "Content",
+            "type": "string"
+          },
+          "crdate": {
+            "description": "系统日志的时间",
+            "format": "date-time",
+            "title": "Crdate",
+            "type": "string"
+          },
+          "id": {
+            "description": "系统日志的id",
+            "title": "Id",
+            "type": "integer"
+          },
+          "log_type": {
+            "description": "系统日志的类型, 1 表示系统负载，2 表示docker状态，3 表示探针状态",
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
+            "title": "Log Type",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "log_type",
+          "content",
+          "crdate"
+        ],
+        "title": "SystemLogDetail",
+        "type": "object"
+      },
+      "SystemLogRet": {
+        "description": "分页类响应的通用模式",
+        "properties": {
+          "data": {
+            "description": "实际返回的数据",
+            "items": {
+              "$ref": "#/components/schemas/SystemLogDetail"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "total": {
+            "description": "满足条件的记录总数",
+            "minimum": 0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "data"
+        ],
+        "title": "SystemLogRet",
+        "type": "object"
+      },
+      "SystemStatusDetail": {
+        "properties": {
+          "mem": {
+            "description": "当前系统的内存占用",
+            "title": "Mem",
+            "type": "number"
+          }
+        },
+        "required": [
+          "mem"
+        ],
+        "title": "SystemStatusDetail",
+        "type": "object"
+      },
+      "ThreatCfgInfo": {
+        "properties": {
+          "access_key": {
+            "description": "access key id",
+            "title": "Access Key",
+            "type": "string"
+          },
+          "available": {
+            "description": "威胁情报配置是否可用, 防止无效配置不断请求",
+            "title": "Available",
+            "type": "boolean"
+          },
+          "enable": {
+            "description": "开启威胁情报",
+            "title": "Enable",
+            "type": "boolean"
+          },
+          "secret": {
+            "description": "access secret",
+            "title": "Secret",
+            "type": "string"
+          },
+          "source": {
+            "description": "数据来源",
+            "title": "Source",
+            "type": "string"
+          },
+          "token": {
+            "description": "token",
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "enable",
+          "source",
+          "access_key",
+          "available"
+        ],
+        "title": "ThreatCfgInfo",
+        "type": "object"
+      },
+      "UpdateScanPortmapData": {
+        "properties": {
+          "agent_sn": {
+            "description": "探针",
+            "title": "Agent Sn",
+            "type": "string"
+          },
+          "node_sn": {
+            "description": "节点的sn",
+            "title": "Node Sn",
+            "type": "string"
+          },
+          "ports": {
+            "default": [],
+            "description": "端口列表",
+            "items": {
+              "$ref": "#/components/schemas/ScanPortmaps"
+            },
+            "title": "Ports",
+            "type": "array"
+          },
+          "service_ips": {
+            "default": [],
+            "description": "服务ip列表",
+            "items": {
+              "type": "string"
+            },
+            "title": "Service Ips",
+            "type": "array"
+          }
+        },
+        "required": [
+          "agent_sn"
+        ],
+        "title": "UpdateScanPortmapData",
+        "type": "object"
+      },
+      "UpstreamPackageBaseInfoRet": {
+        "properties": {
+          "description": {
+            "description": "描述信息",
+            "title": "Description",
+            "type": "string"
+          },
+          "downloaded_size": {
+            "description": "已经下载的文件大小",
+            "title": "Downloaded Size",
+            "type": "integer"
+          },
+          "filename": {
+            "description": "文件名",
+            "title": "Filename",
+            "type": "string"
+          },
+          "id": {
+            "description": "升级包ID",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "description": "升级包名称",
+            "title": "Name",
+            "type": "string"
+          },
+          "need_version": {
+            "description": "适用版本",
+            "title": "Need Version",
+            "type": "string"
+          },
+          "published_time": {
+            "description": "发布时间",
+            "title": "Published Time",
+            "type": "string"
+          },
+          "size": {
+            "description": "文件大小",
+            "title": "Size",
+            "type": "integer"
+          },
+          "status": {
+            "description": "当前下载状态(5表示未下载，6代表下载中，7代表下载失败，8代表下载完成)",
+            "enum": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ],
+            "title": "Status",
+            "type": "integer"
+          },
+          "type": {
+            "description": "文件类型",
+            "enum": [
+              "",
+              "patch",
+              "manager",
+              "honeypot",
+              "agent"
+            ],
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "filename",
+          "type",
+          "size",
+          "downloaded_size",
+          "description",
+          "need_version",
+          "published_time",
+          "status"
+        ],
+        "title": "UpstreamPackageBaseInfoRet",
+        "type": "object"
+      },
+      "UserChangeLoginMethod": {
+        "properties": {
+          "code": {
+            "default": "",
+            "description": "证书文件名",
+            "title": "Code",
+            "type": "string"
+          },
+          "login_method": {
+            "description": "用户登录方式",
+            "title": "Login Method",
+            "type": "string"
+          },
+          "password": {
+            "default": "",
+            "description": "导入证书密码",
+            "title": "Password",
+            "type": "string"
+          },
+          "username": {
+            "description": "用户名",
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "login_method",
+          "username"
+        ],
+        "title": "UserChangeLoginMethod",
+        "type": "object"
+      },
+      "UserManageConfigDetail": {
+        "properties": {
+          "error_count": {
+            "description": "允许登录的最大失败次数",
+            "exclusiveMinimum": true,
+            "minimum": 0,
+            "title": "Error Count",
+            "type": "integer"
+          },
+          "lock_time": {
+            "description": "账号禁用分钟数",
+            "exclusiveMinimum": true,
+            "minimum": 0,
+            "title": "Lock Time",
+            "type": "integer"
+          },
+          "password_timeout": {
+            "description": "提示密码修改的天数，为None时表示不提示",
+            "title": "Password Timeout",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "lock_time",
+          "error_count"
+        ],
+        "title": "UserManageConfigDetail",
+        "type": "object"
+      },
+      "VirtualIPDetail": {
+        "properties": {
+          "end_ip": {
+            "description": "虚拟ip结束地址",
+            "format": "ipvanyaddress",
+            "title": "End Ip",
+            "type": "string"
+          },
+          "id": {
+            "default": "",
+            "description": "id",
+            "title": "Id",
+            "type": "string"
+          },
+          "mask": {
+            "description": "子网掩码",
+            "title": "Mask",
+            "type": "string"
+          },
+          "start_ip": {
+            "description": "虚拟ip开始地址",
+            "format": "ipvanyaddress",
+            "title": "Start Ip",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start_ip",
+          "end_ip",
+          "mask"
+        ],
+        "title": "VirtualIPDetail",
+        "type": "object"
+      },
+      "WebshellConfigInfo": {
+        "properties": {
+          "address": {
+            "description": "webshell探针地址",
+            "title": "Address",
+            "type": "string"
+          },
+          "type": {
+            "description": "webshell类型(1代表jsp，2代表php5，3代表php7)",
+            "enum": [
+              "jsp",
+              "php5",
+              "php7"
+            ],
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "address"
+        ],
+        "title": "WebshellConfigInfo",
+        "type": "object"
+      },
+      "WenjinCfgInfo": {
+        "properties": {
+          "address": {
+            "description": "问津地址",
+            "title": "Address",
+            "type": "string"
+          },
+          "token": {
+            "description": "问津token",
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "address"
+        ],
+        "title": "WenjinCfgInfo",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "产品 API 文档",
+    "version": "1.0.0"
+  },
+  "openapi": "3.0.2",
+  "paths": {
+    "/api/agent/detail": {
+      "post": {
+        "operationId": "agent_detail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "sn": {
+                    "description": "探针的sn",
+                    "title": "Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sn"
+                ],
+                "title": "AgentDetailArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "可空响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/AgentDetail"
+                    }
+                  },
+                  "title": "AgentDetailRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取探针详情",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/list": {
+      "post": {
+        "operationId": "list_agent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": [],
+                    "description": "探针ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Agent Ids",
+                    "type": "array"
+                  },
+                  "business_group": {
+                    "default": "",
+                    "description": "根据业务组进行过滤",
+                    "title": "Business Group",
+                    "type": "string"
+                  },
+                  "honeypots": {
+                    "default": [],
+                    "description": "蜜罐的ID，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypots",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "local_addr": {
+                    "default": [],
+                    "description": "支持对外ip筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Local Addr",
+                    "type": "array"
+                  },
+                  "modes": {
+                    "default": [],
+                    "description": "探针运行模式, 列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        "null",
+                        "probe"
+                      ],
+                      "type": "string"
+                    },
+                    "title": "Modes",
+                    "type": "array"
+                  },
+                  "names": {
+                    "default": [],
+                    "description": "探针名称中包含的字符串, 列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Names",
+                    "type": "array"
+                  },
+                  "network_status": {
+                    "description": "探针网卡状态，'0'表示异常，'1'表示正常",
+                    "enum": [
+                      "0",
+                      "1"
+                    ],
+                    "title": "Network Status",
+                    "type": "string"
+                  },
+                  "node": {
+                    "description": "节点信息",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "order_by": {
+                    "default": [],
+                    "description": "支持排序功能，目前仅支持AgentOrderTypeEnum以下类型",
+                    "items": {
+                      "$ref": "#/components/schemas/OrderByInfo"
+                    },
+                    "title": "Order By",
+                    "type": "array"
+                  },
+                  "os_infos": {
+                    "default": [],
+                    "description": "探针所在主机的操作系统详细信息，列表为空时不对此项做筛选",
+                    "items": {
+                      "$ref": "#/components/schemas/AgentOSInfo"
+                    },
+                    "title": "Os Infos",
+                    "type": "array"
+                  },
+                  "os_types": {
+                    "default": [],
+                    "description": "探针所在主机的操作系统类型，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        "windows",
+                        "linux"
+                      ],
+                      "type": "string"
+                    },
+                    "title": "Os Types",
+                    "type": "array"
+                  },
+                  "service_states": {
+                    "default": [],
+                    "description": "探针的服务状态, 当列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        1,
+                        2,
+                        3,
+                        4
+                      ],
+                      "type": "integer"
+                    },
+                    "title": "Service States",
+                    "type": "array"
+                  },
+                  "set_proxy": {
+                    "default": false,
+                    "description": "根据探针是否使用proxyproto协议做筛选，False是不使用",
+                    "items": {
+                      "type": "boolean"
+                    },
+                    "title": "Set Proxy",
+                    "type": "array"
+                  },
+                  "states": {
+                    "default": [],
+                    "description": "探针运行状态，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        "online",
+                        "offline",
+                        "unprobe",
+                        "unnormal"
+                      ],
+                      "type": "string"
+                    },
+                    "title": "States",
+                    "type": "array"
+                  },
+                  "users": {
+                    "default": [],
+                    "description": "探针所属用户名中包含的字符串, 列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Users",
+                    "type": "array"
+                  },
+                  "version_states": {
+                    "default": [],
+                    "description": "探针版本状态, 列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        "latest",
+                        "compatible",
+                        "outdated"
+                      ],
+                      "type": "string"
+                    },
+                    "title": "Version States",
+                    "type": "array"
+                  }
+                },
+                "title": "ListAgentArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "description": "实际返回的数据",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "offline": {
+                      "description": "当前离线的探针数",
+                      "title": "Offline",
+                      "type": "integer"
+                    },
+                    "online": {
+                      "description": "当前服务正常探针数",
+                      "title": "Online",
+                      "type": "integer"
+                    },
+                    "total": {
+                      "description": "满足条件的记录总数",
+                      "minimum": 0,
+                      "title": "Total",
+                      "type": "integer"
+                    },
+                    "unnormal": {
+                      "description": "当前服务异常的探针数",
+                      "title": "Unnormal",
+                      "type": "integer"
+                    },
+                    "unprobe": {
+                      "description": "当前未授权的探针数",
+                      "title": "Unprobe",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "data",
+                    "online",
+                    "unnormal",
+                    "unprobe",
+                    "offline"
+                  ],
+                  "title": "ListAgentRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "探针列表",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/os_version/list": {
+      "post": {
+        "operationId": "list_os_version",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "当前用户所有探针所在主机操作系统信息去重后的列表",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentOSInfo"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "ListOSVersionRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "探针操作系统列表（用于筛选项）",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/portmap/update": {
+      "post": {
+        "operationId": "update_agent_portmap",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "port_maps": {
+                    "description": "添加/更新探针对应服务的列表",
+                    "items": {
+                      "$ref": "#/components/schemas/Portmaps"
+                    },
+                    "title": "Port Maps",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "port_maps"
+                ],
+                "title": "UpdatePortmapArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "通用模式",
+                  "properties": {
+                    "data": {
+                      "description": "操作失败的探针服务sn列表",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UpdatePortmapRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新探针服务（不包括端口探测服务）",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/portmap/scan/update": {
+      "post": {
+        "operationId": "update_agent_scan_portmap",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "port_maps": {
+                    "description": "服务列表",
+                    "items": {
+                      "$ref": "#/components/schemas/UpdateScanPortmapData"
+                    },
+                    "title": "Port Maps",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "port_maps"
+                ],
+                "title": "UpdateScanPortmapArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UpdateScanPortmapRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新探针端口探测",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/portmap/scan/get": {
+      "post": {
+        "operationId": "get_agent_scan_portmap",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_sn": {
+                    "description": "探针ID",
+                    "title": "Agent Sn",
+                    "type": "string"
+                  },
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "agent_sn"
+                ],
+                "title": "GetScanPortmapArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetScanPortmapData"
+                        }
+                      ],
+                      "description": "端口探测数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetScanPortmapRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取探针端口探测服务数据",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/portmap/delete": {
+      "post": {
+        "operationId": "delete_agent_portmap",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "port_maps": {
+                    "additionalProperties": {
+                      "items": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "default": {},
+                    "description": "探针ID和服务ID的映射",
+                    "title": "Port Maps",
+                    "type": "object"
+                  }
+                },
+                "title": "DeleteAgentArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除探针服务（不包括端口探测服务）",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/portmap/batch_delete": {
+      "post": {
+        "operationId": "batch_delete_agent_portmap",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "datas": {
+                    "description": "批量删除探针绑定的服务列表",
+                    "items": {
+                      "$ref": "#/components/schemas/BatchDeletePortmapData"
+                    },
+                    "title": "Datas",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "datas"
+                ],
+                "title": "BatchDeletePortmapArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "通用模式",
+                  "properties": {
+                    "data": {
+                      "description": "删除服务失败的探针sn列表",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "BatchDeletePortmapRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "批量删除探针绑定的某些服务",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/change_type": {
+      "post": {
+        "operationId": "change_agent_type",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "datas": {
+                    "description": "清空探针服务",
+                    "items": {
+                      "$ref": "#/components/schemas/AgentChangeTypeArg"
+                    },
+                    "title": "Datas",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "datas"
+                ],
+                "title": "UpdateAgentArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "失败的探针的sn列表",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AgentChangeTypeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新探针配置",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/clear_service": {
+      "post": {
+        "operationId": "clear_agents_service",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "datas": {
+                    "description": "清空探针服务",
+                    "items": {
+                      "$ref": "#/components/schemas/BatchClearAgentService"
+                    },
+                    "title": "Datas",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "datas"
+                ],
+                "title": "ClearAgentsArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ClearAgentsServiceRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "清理探针服务",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/version_update": {
+      "post": {
+        "operationId": "version_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node_sn": {
+                    "default": "",
+                    "description": "节点sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "sns": {
+                    "default": [],
+                    "description": "探针的sn列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Sns",
+                    "type": "array"
+                  }
+                },
+                "title": "UpAgentArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "升级探针",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/ip/list": {
+      "post": {
+        "operationId": "list_agent_ip",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "sn": {
+                    "description": "探针的sn",
+                    "title": "Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sn"
+                ],
+                "title": "AgentDetailArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AgentListData"
+                        }
+                      ],
+                      "default": {},
+                      "description": "探针ip信息",
+                      "title": "Data"
+                    }
+                  },
+                  "title": "ListAgentIpRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "配置探针服务中的ip列表",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/ip/all": {
+      "post": {
+        "operationId": "list_all_agent_ip_view",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  }
+                },
+                "title": "AllCanListenIPListArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "可监听的所有ip",
+                      "items": {
+                        "$ref": "#/components/schemas/AllCanListenIPBaseItem"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AllCanListenIPListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取所有探针的可监听ip列表",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/multi_ip/list": {
+      "post": {
+        "operationId": "list_multi_agent_ip",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "sns": {
+                    "default": [],
+                    "description": "探针的sn列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Sns",
+                    "type": "array"
+                  }
+                },
+                "title": "AgentArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AgentListData"
+                        }
+                      ],
+                      "default": {},
+                      "description": "探针ip信息",
+                      "title": "Data"
+                    }
+                  },
+                  "title": "ListAgentIpRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "批量获取配置探针服务中的ip列表",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/business_group/post": {
+      "post": {
+        "operationId": "business_group_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "节点的id",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "节点名称",
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "parent": {
+                    "default": "",
+                    "description": "父节点的id",
+                    "title": "Parent",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "title": "AddNodeArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AddNodeRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "添加节点的返回参数",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AddRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "新增一个业务组节点的信息",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/business_group/put": {
+      "post": {
+        "operationId": "business_group_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "children": {
+                    "default": [],
+                    "description": "子节点信息",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Children",
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "节点的id",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "节点名称",
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "parent": {
+                    "default": "",
+                    "description": "父节点的id",
+                    "format": "uuid",
+                    "title": "Parent",
+                    "type": "string"
+                  }
+                },
+                "title": "UpdateNodeArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "更新节点的返回",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UpdateRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改业务组节点的信息",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/business_group/put_agent": {
+      "post": {
+        "operationId": "business_group_put_agent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agentIds": {
+                    "description": "探针id列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Agentids",
+                    "type": "array"
+                  },
+                  "groupId": {
+                    "default": "",
+                    "description": "业务组id",
+                    "title": "Groupid",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "agentIds"
+                ],
+                "title": "PutAgentArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "移动节点到业务组的返回",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "PutAgentRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "将节点移动到其他业务组",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/business_group/delete": {
+      "post": {
+        "operationId": "business_group_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "default": "",
+                    "description": "节点的id",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "title": "DeleteGroupArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "删除节点的返回",
+                      "title": "Data"
+                    }
+                  },
+                  "title": "DeleteRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除业务组节点",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/business_group/get_full": {
+      "post": {
+        "operationId": "business_group_get_full",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "GetFullArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetFullRet"
+                        }
+                      ],
+                      "description": "获取整个树数据的结果返回",
+                      "title": "Data"
+                    }
+                  },
+                  "title": "GetFullDataRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取整个树数据的结果返回",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/business_group/get_all_group": {
+      "post": {
+        "operationId": "business_group_get_all_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "show_listen_ip": {
+                    "default": false,
+                    "description": "是否需要探针监听地址",
+                    "title": "Show Listen Ip",
+                    "type": "boolean"
+                  },
+                  "username": {
+                    "description": "需要过滤的探针用户名",
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "title": "GetAllNodeArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "不包含探针的树形节点",
+                      "items": {
+                        "type": "object"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetAllNodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取业务组列表（不包含探针的树形节点）",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/business_group/get_all_agent": {
+      "post": {
+        "operationId": "business_group_get_all_agent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "show_listen_ip": {
+                    "default": false,
+                    "description": "是否需要探针监听地址",
+                    "title": "Show Listen Ip",
+                    "type": "boolean"
+                  },
+                  "username": {
+                    "description": "需要过滤的探针用户名",
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "title": "GetAllNodeArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "不包含探针的树形节点",
+                      "items": {
+                        "type": "object"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetAllNodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取业务组列表（包含探针的树形节点）",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/proto_cfg/get": {
+      "post": {
+        "operationId": "get_proto_cfg",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "通用模式",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ProtoCfg"
+                    },
+                    "err": {
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ProtoCfgRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取联动 协议配置",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/proto_cfg/set": {
+      "post": {
+        "operationId": "set_proto_cfg",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "enable_token": {
+                    "description": "是否启用token",
+                    "title": "Enable Token",
+                    "type": "boolean"
+                  },
+                  "proto_mode": {
+                    "default": "proxyproto",
+                    "description": "协议类型，proxyproto, default",
+                    "enum": [
+                      "proxyproto",
+                      "default"
+                    ],
+                    "title": "Proto Mode",
+                    "type": "string"
+                  },
+                  "proto_token": {
+                    "title": "Proto Token",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "enable_token"
+                ],
+                "title": "ProtoCfg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "通用模式",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ProtoCfg"
+                    },
+                    "err": {
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ProtoCfgRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "联动配置",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/agent_proxy/set": {
+      "post": {
+        "operationId": "set_agent_proxy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "sns": {
+                    "default": [],
+                    "description": "探针的sn列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Sns",
+                    "type": "array"
+                  }
+                },
+                "title": "AgentProxyArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "探针是否成功启用proxyproto",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AgentProxyRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "探针是否开启proxyproto协议",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/agent_proxy/get": {
+      "post": {
+        "operationId": "get_agent_proxy",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "description": "实际返回的数据",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    },
+                    "total": {
+                      "description": "满足条件的记录总数",
+                      "minimum": 0,
+                      "title": "Total",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "data"
+                  ],
+                  "title": "GetAgentProxyRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "开启proxyproto协议的探针",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/vlan/get": {
+      "post": {
+        "operationId": "agent_vlan_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ip": {
+                    "description": "搜索的ip",
+                    "format": "ipvanyaddress",
+                    "title": "Ip",
+                    "type": "string"
+                  },
+                  "node_sn": {
+                    "description": "节点sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "sn": {
+                    "description": "探针的sn",
+                    "title": "Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sn"
+                ],
+                "title": "ListAgentVlanArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "探针的接口列表",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentVlanDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ListAgentVlanRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取探针的网卡接口列表",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/vlan/post": {
+      "post": {
+        "operationId": "agent_vlan_add",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_sn": {
+                    "description": "探针的sn",
+                    "title": "Agent Sn",
+                    "type": "string"
+                  },
+                  "node_sn": {
+                    "description": "节点sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "parent_interface_id": {
+                    "description": "父接口id",
+                    "title": "Parent Interface Id",
+                    "type": "string"
+                  },
+                  "vlan_id": {
+                    "description": "接口所属vlan id",
+                    "title": "Vlan Id",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "agent_sn",
+                  "parent_interface_id",
+                  "vlan_id"
+                ],
+                "title": "AgentVlanPostArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "当前的所有网口信息",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentVlanDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AgentVlanPostRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "增加虚拟网卡接口",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/vlan/delete": {
+      "post": {
+        "operationId": "agent_vlan_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "要删除探针虚拟网卡的id",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "node_sn": {
+                    "description": "节点sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "AgentVlanDeleteArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "当前的所有网口信息",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentVlanDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AgentVlanDeleteRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除虚拟网卡接口",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/vlan_ip/put": {
+      "post": {
+        "operationId": "virtual_ip_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "虚拟网卡接口的id",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "ips": {
+                    "description": "配置的ip信息",
+                    "items": {
+                      "$ref": "#/components/schemas/VirtualIPDetail"
+                    },
+                    "title": "Ips",
+                    "type": "array"
+                  },
+                  "node_sn": {
+                    "description": "节点sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "ips"
+                ],
+                "title": "VirtualIPUpdateArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "当前的所有网口信息",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentVlanDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "VirtualIPUpdateRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "虚拟ip配置更新",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/route/update": {
+      "post": {
+        "operationId": "agent_route_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "gateway": {
+                    "default": "",
+                    "description": "网关地址",
+                    "title": "Gateway",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "虚拟网卡接口的id",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "UpdateGatewayArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "当前的所有网口信息",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentVlanDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UpdateGatewayRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新网关",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/vlan/confirm_import": {
+      "post": {
+        "operationId": "confirm_import_ip_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_id": {
+                    "description": "探针的id",
+                    "title": "Agent Id",
+                    "type": "string"
+                  },
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "vlan_ip_config": {
+                    "description": "需要导入的探针的配置",
+                    "items": {
+                      "$ref": "#/components/schemas/AgentVlanIPConfig"
+                    },
+                    "title": "Vlan Ip Config",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "agent_id",
+                  "vlan_ip_config"
+                ],
+                "title": "ConfirmImportIPArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "导入是否成功",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ConfirmImportIPRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "确认批量导入vlan ip 配置",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/captain/status": {
+      "post": {
+        "operationId": "captain_agent_status",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "当前的所有网口信息",
+                      "items": {
+                        "$ref": "#/components/schemas/CaptainAgentStatus"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "CaptainAgentStatusRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "集中管理探针状态",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/interface_ip/update": {
+      "post": {
+        "operationId": "interface_ip_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "虚拟网卡接口的id",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "ips": {
+                    "description": "配置的ip信息",
+                    "items": {
+                      "$ref": "#/components/schemas/VirtualIPDetail"
+                    },
+                    "title": "Ips",
+                    "type": "array"
+                  },
+                  "node_sn": {
+                    "description": "节点sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "ips"
+                ],
+                "title": "InterfaceIPUpdateArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "当前的所有网口信息",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentVlanDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "添加节点错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "添加节点失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "InterfaceIPUpdateRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "网口ip配置更新",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/interface_gateway/update": {
+      "post": {
+        "operationId": "interface_gateway_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "gateway": {
+                    "default": "",
+                    "description": "网关地址",
+                    "title": "Gateway",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "网口id",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "InterfaceGatewayUpdateArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "当前的所有网口信息",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentVlanDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "InterfaceGatewayUpdateRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "软件探针更新网关",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/interface/get": {
+      "post": {
+        "operationId": "agent_interface_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ip": {
+                    "description": "搜索的ip",
+                    "format": "ipvanyaddress",
+                    "title": "Ip",
+                    "type": "string"
+                  },
+                  "node_sn": {
+                    "description": "节点sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "sn": {
+                    "description": "探针的sn",
+                    "title": "Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sn"
+                ],
+                "title": "ListAgentVlanArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "探针的接口列表",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentVlanDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ListAgentVlanRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取探针的网卡接口列表",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/can_listen_ips/get": {
+      "post": {
+        "operationId": "can_listen_ip_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_sn": {
+                    "description": "探针的sn",
+                    "title": "Agent Sn",
+                    "type": "string"
+                  },
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "agent_sn"
+                ],
+                "title": "CanListenIPListArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "可监听的所有ip",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "CanListenIPListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取可监听ip列表",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/can_listen_ips/update": {
+      "post": {
+        "operationId": "update_listen_ip_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_sn": {
+                    "description": "探针的sn",
+                    "title": "Agent Sn",
+                    "type": "string"
+                  },
+                  "ips": {
+                    "description": "可监听的所有ip",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ips",
+                    "type": "array"
+                  },
+                  "node_sn": {
+                    "description": "节点的sn",
+                    "title": "Node Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ips",
+                  "agent_sn"
+                ],
+                "title": "UpdateListenIPListArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "可监听的所有ip",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UpdateListenIPListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新可监听ip列表",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/batch_install_agents/get_install_status": {
+      "post": {
+        "operationId": "get_install_status",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AgentInstallStatus"
+                        }
+                      ],
+                      "default": "",
+                      "description": "当前探针安装状态信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AgentInstallStatusRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取批量安装探针状态",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/batch_install_agents/start_install": {
+      "post": {
+        "operationId": "start_install_agent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "server": {
+                    "description": "当前用户登陆谛听的ip",
+                    "title": "Server",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "server"
+                ],
+                "title": "StartInstallAgentArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "开始批量安装探针是否成功",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "StartInstallAgentRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "开始批量安装探针",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/batch_install_agents/reset_install_status": {
+      "post": {
+        "operationId": "reset_install_status",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "重置批量安装状态是否成功",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ResetAgentInstallStatusRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "重置批量安装探针状态",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/batch_config/arp": {
+      "post": {
+        "operationId": "batch_config_arp",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "arp": {
+                    "description": "arp探测开关",
+                    "title": "Arp",
+                    "type": "boolean"
+                  },
+                  "sns": {
+                    "default": [],
+                    "description": "探针的sn列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Sns",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "arp"
+                ],
+                "title": "BatchConfigArpArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "批量配置探针的arp检测服务",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/batch_config/ping": {
+      "post": {
+        "operationId": "batch_config_ping",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ping": {
+                    "description": "arp探测开关",
+                    "title": "Ping",
+                    "type": "boolean"
+                  },
+                  "sns": {
+                    "default": [],
+                    "description": "探针的sn列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Sns",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ping"
+                ],
+                "title": "BatchConfigPingArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "批量配置探针的ping检测服务",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/batch_config/receiver": {
+      "post": {
+        "operationId": "batch_config_receiver",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "receiver": {
+                    "description": "御衡接收端是否启动",
+                    "title": "Receiver",
+                    "type": "boolean"
+                  },
+                  "sns": {
+                    "default": [],
+                    "description": "探针的sn列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Sns",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "receiver"
+                ],
+                "title": "BatchConfigReceiverArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "批量配置探针上接收端的状态",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/agent/batch_config/ping_detection": {
+      "post": {
+        "operationId": "batch_config_detection",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ping_detection": {
+                    "description": "是否开启ping网关",
+                    "title": "Ping Detection",
+                    "type": "boolean"
+                  },
+                  "sns": {
+                    "default": [],
+                    "description": "探针的sn列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Sns",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ping_detection"
+                ],
+                "title": "BatchConfigPingDetectionArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "批量配置大探针ping网关功能",
+        "tags": [
+          "探针管理"
+        ]
+      }
+    },
+    "/api/audit/list/": {
+      "post": {
+        "operationId": "audit_log_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "data_detail_list": {
+                    "default": false,
+                    "description": "操作内容",
+                    "items": {},
+                    "title": "Data Detail List",
+                    "type": "array"
+                  },
+                  "ip_list": {
+                    "default": false,
+                    "description": "ip",
+                    "items": {},
+                    "title": "Ip List",
+                    "type": "array"
+                  },
+                  "is_master": {
+                    "default": true,
+                    "description": "节点sn号",
+                    "title": "Is Master",
+                    "type": "boolean"
+                  },
+                  "keyword_list": {
+                    "default": false,
+                    "description": "关键字",
+                    "items": {},
+                    "title": "Keyword List",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "model_involved_list": {
+                    "default": false,
+                    "description": "涉及模块",
+                    "items": {},
+                    "title": "Model Involved List",
+                    "type": "array"
+                  },
+                  "node_sn": {
+                    "default": "",
+                    "description": "节点sn号",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "某个时间之前的日志",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "default": "1970-01-01 00:00:00.000000",
+                    "description": "某个时间之后的日志",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "operation_type_list": {
+                    "default": false,
+                    "description": "操作类型",
+                    "items": {},
+                    "title": "Operation Type List",
+                    "type": "array"
+                  },
+                  "type_list": {
+                    "default": false,
+                    "description": "操作类型",
+                    "items": {},
+                    "title": "Type List",
+                    "type": "array"
+                  },
+                  "username_list": {
+                    "default": false,
+                    "description": "用户名",
+                    "items": {},
+                    "title": "Username List",
+                    "type": "array"
+                  }
+                },
+                "title": "LogListArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "LogListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "审计日志列表",
+        "tags": [
+          "用户操作日志"
+        ]
+      }
+    },
+    "/api/audit/query/": {
+      "post": {
+        "operationId": "audit_log_detail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "log_id": {
+                    "description": "日志id",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "Log Id",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "log_id"
+                ],
+                "title": "LogQueryArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/LogDetail"
+                        }
+                      ],
+                      "description": "审计日志详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "LogQueryRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "筛选审计日志",
+        "tags": [
+          "用户操作日志"
+        ]
+      }
+    },
+    "/api/audit/download/": {
+      "post": {
+        "operationId": "audit_log_download",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data_detail_list": {
+                    "default": false,
+                    "description": "操作内容",
+                    "items": {},
+                    "title": "Data Detail List",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "根据id筛选",
+                    "items": {},
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "ip_list": {
+                    "default": false,
+                    "description": "ip",
+                    "items": {},
+                    "title": "Ip List",
+                    "type": "array"
+                  },
+                  "is_master": {
+                    "default": true,
+                    "description": "节点sn号",
+                    "title": "Is Master",
+                    "type": "boolean"
+                  },
+                  "keyword_list": {
+                    "default": false,
+                    "description": "关键字",
+                    "items": {},
+                    "title": "Keyword List",
+                    "type": "array"
+                  },
+                  "model_involved_list": {
+                    "default": false,
+                    "description": "涉及模块",
+                    "items": {},
+                    "title": "Model Involved List",
+                    "type": "array"
+                  },
+                  "node_sn": {
+                    "default": "",
+                    "description": "节点sn号",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "某个时间之前的日志",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "default": "1970-01-01 00:00:00.000000",
+                    "description": "某个时间之后的日志",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "operation_type_list": {
+                    "default": false,
+                    "description": "操作类型",
+                    "items": {},
+                    "title": "Operation Type List",
+                    "type": "array"
+                  },
+                  "type_list": {
+                    "default": false,
+                    "description": "操作类型",
+                    "items": {},
+                    "title": "Type List",
+                    "type": "array"
+                  },
+                  "username_list": {
+                    "default": false,
+                    "description": "用户名",
+                    "items": {},
+                    "title": "Username List",
+                    "type": "array"
+                  }
+                },
+                "title": "LogDownLoadArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "下载审计日志",
+                      "title": "Data",
+                      "type": "string"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "LogDownLoadRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "下载审计日志",
+        "tags": [
+          "用户操作日志"
+        ]
+      }
+    },
+    "/api/audit/delete/": {
+      "post": {
+        "operationId": "audit_log_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data_detail_list": {
+                    "default": false,
+                    "description": "操作内容",
+                    "items": {},
+                    "title": "Data Detail List",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "根据id筛选日志",
+                    "items": {},
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "ip_list": {
+                    "default": false,
+                    "description": "ip",
+                    "items": {},
+                    "title": "Ip List",
+                    "type": "array"
+                  },
+                  "is_master": {
+                    "default": true,
+                    "description": "节点sn号",
+                    "title": "Is Master",
+                    "type": "boolean"
+                  },
+                  "keyword_list": {
+                    "default": false,
+                    "description": "关键字",
+                    "items": {},
+                    "title": "Keyword List",
+                    "type": "array"
+                  },
+                  "model_involved_list": {
+                    "default": false,
+                    "description": "涉及模块",
+                    "items": {},
+                    "title": "Model Involved List",
+                    "type": "array"
+                  },
+                  "node_sn": {
+                    "default": "",
+                    "description": "节点sn号",
+                    "title": "Node Sn",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "某个时间之前的日志",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "default": "1970-01-01 00:00:00.000000",
+                    "description": "某个时间之后的日志",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "operation_type_list": {
+                    "default": false,
+                    "description": "操作类型",
+                    "items": {},
+                    "title": "Operation Type List",
+                    "type": "array"
+                  },
+                  "type_list": {
+                    "default": false,
+                    "description": "操作类型",
+                    "items": {},
+                    "title": "Type List",
+                    "type": "array"
+                  },
+                  "username_list": {
+                    "default": false,
+                    "description": "用户名",
+                    "items": {},
+                    "title": "Username List",
+                    "type": "array"
+                  }
+                },
+                "title": "LogDeleteArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "删除审计日志总数",
+                      "title": "Data",
+                      "type": "integer"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "LogDeleteRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除审计日志",
+        "tags": [
+          "用户操作日志"
+        ]
+      }
+    },
+    "/api/alarm/smtp/get": {
+      "post": {
+        "operationId": "get_smtp_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "邮件发信配置模版id列表",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "title": "GetSMTPConfigArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "获取SMTP服务器配置详情",
+                      "items": {
+                        "$ref": "#/components/schemas/SMTPServerDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetSMTPConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "SMTP服务器配置详情",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/smtp/set": {
+      "post": {
+        "operationId": "set_smtp_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "address": {
+                    "description": "发件邮箱地址",
+                    "title": "Address",
+                    "type": "string"
+                  },
+                  "display_name": {
+                    "description": "smtp模版名称",
+                    "title": "Display Name",
+                    "type": "string"
+                  },
+                  "email": {
+                    "description": "发件邮箱账号",
+                    "title": "Email",
+                    "type": "string"
+                  },
+                  "event_last_send": {
+                    "description": "最后一次发送事件的时间",
+                    "format": "date-time",
+                    "title": "Event Last Send",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "smtp配置模版id",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "monthly_last_send": {
+                    "description": "每月的最后一次发送时间",
+                    "format": "date-time",
+                    "title": "Monthly Last Send",
+                    "type": "string"
+                  },
+                  "no_key": {
+                    "default": false,
+                    "description": "是否设置密码",
+                    "title": "No Key",
+                    "type": "boolean"
+                  },
+                  "password": {
+                    "default": "",
+                    "description": "发件邮箱密码",
+                    "title": "Password",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "SMTP 服务器端口号",
+                    "title": "Port",
+                    "type": "integer"
+                  },
+                  "server": {
+                    "description": "SMTP 服务器地址",
+                    "title": "Server",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "传输加密方式",
+                    "title": "Type",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "smtp模版所属用户",
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "server",
+                  "port",
+                  "email"
+                ],
+                "title": "SetSMTPConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/SMTPServerDetail"
+                        }
+                      ],
+                      "description": "设置SMTP服务器",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SetSMTPConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "配置SMTP服务器",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/smtp/test": {
+      "post": {
+        "operationId": "smtp_test",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "email": {
+                    "description": "测试邮箱",
+                    "title": "Email",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "所使用的smtp配置的id",
+                    "title": "Id",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "email",
+                  "id"
+                ],
+                "title": "SMTPTestArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "测试邮箱",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SMTPTestRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "测试邮箱",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/smtp/delete": {
+      "post": {
+        "operationId": "smtp_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "待删除webhook配置的ids列表",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "SmtpConfigDeleteArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "Webhook配置删除的响应结果",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "Webhook配置删除失败的描述",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "Webhook配置删除的详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SmtpConfigDeleteRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除SMTP服务器",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/firewall/rules/set": {
+      "post": {
+        "operationId": "firewall_rule_set",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "alarm_agents": {
+                    "default": [],
+                    "description": "告警的探针范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Agents",
+                    "type": "array"
+                  },
+                  "alarm_groups": {
+                    "default": [],
+                    "description": "告警的业务组范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Groups",
+                    "type": "array"
+                  },
+                  "alarm_groups_tree": {
+                    "description": "告警的蜜罐范围树，用于前端显示",
+                    "items": {
+                      "type": "object"
+                    },
+                    "title": "Alarm Groups Tree",
+                    "type": "array"
+                  },
+                  "alarm_honeynets": {
+                    "default": [],
+                    "description": "告警的蜜网范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Honeynets",
+                    "type": "array"
+                  },
+                  "alarm_honeypots": {
+                    "default": [],
+                    "description": "告警的蜜罐范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Honeypots",
+                    "type": "array"
+                  },
+                  "arp_event": {
+                    "description": "检测到ARP攻击时报告",
+                    "title": "Arp Event",
+                    "type": "boolean"
+                  },
+                  "connection_event": {
+                    "description": "检测到蜜罐入侵时报告",
+                    "title": "Connection Event",
+                    "type": "boolean"
+                  },
+                  "connection_event_risk_level": {
+                    "description": "蜜罐入侵事件的风险级别,1表示无威胁 2表示低危, 3表示中危, 4表示高危",
+                    "enum": [
+                      1,
+                      2,
+                      3,
+                      4
+                    ],
+                    "title": "Connection Event Risk Level",
+                    "type": "integer"
+                  },
+                  "enable": {
+                    "default": true,
+                    "description": "是否开启告警模版",
+                    "title": "Enable",
+                    "type": "boolean"
+                  },
+                  "firewall_config_ids": {
+                    "default": [],
+                    "description": "防火墙配置id列表",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Firewall Config Ids",
+                    "type": "array"
+                  },
+                  "ping_event": {
+                    "description": "检测到Ping扫描时报告",
+                    "title": "Ping Event",
+                    "type": "boolean"
+                  },
+                  "portrait": {
+                    "description": "获取攻击者画像时报告",
+                    "title": "Portrait",
+                    "type": "boolean"
+                  },
+                  "scanner_event": {
+                    "description": "检测到端口探测时报告",
+                    "title": "Scanner Event",
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "default": 3,
+                    "description": "模版类型，alert_popup弹窗告警，template告警模版，firewall防火墙规则",
+                    "title": "Type",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "portrait",
+                  "connection_event",
+                  "connection_event_risk_level",
+                  "scanner_event",
+                  "ping_event",
+                  "arp_event"
+                ],
+                "title": "FirewallRuleDetail",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/FirewallRuleDetail"
+                        }
+                      ],
+                      "description": "更新防火墙阈值规则",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SetFirewallRule",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新防火墙阈值规则",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/firewall/rules/get": {
+      "post": {
+        "operationId": "firewall_rule_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/FirewallRuleDetail"
+                        }
+                      ],
+                      "description": "获取防火墙阈值规则",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetFirewallRule",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取防火墙阈值规则",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/firewall/set": {
+      "post": {
+        "operationId": "set_firewall",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "addr": {
+                    "description": "三方设备地址",
+                    "title": "Addr",
+                    "type": "string"
+                  },
+                  "agent_ips": {
+                    "description": "牧云探针ip列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Agent Ips",
+                    "type": "array"
+                  },
+                  "api_token": {
+                    "default": "",
+                    "description": "三方设备api-token",
+                    "title": "Api Token",
+                    "type": "string"
+                  },
+                  "device_type": {
+                    "description": "设备类型",
+                    "title": "Device Type",
+                    "type": "integer"
+                  },
+                  "display_name": {
+                    "description": "设备名称",
+                    "title": "Display Name",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "设备id",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "password": {
+                    "default": "",
+                    "description": "三方设备登录密码",
+                    "title": "Password",
+                    "type": "string"
+                  },
+                  "remark": {
+                    "description": "备注",
+                    "title": "Remark",
+                    "type": "string"
+                  },
+                  "status": {
+                    "default": true,
+                    "description": "设备状态，true为启用，false为禁用",
+                    "title": "Status",
+                    "type": "boolean"
+                  },
+                  "username": {
+                    "default": "",
+                    "description": "三方设备登录用户名",
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "title": "CreateFirewallArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/FirewallConfigDetail"
+                        }
+                      ],
+                      "description": "防火墙配置信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "CreateFirewallRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "添加安全设备配置",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/firewall/list": {
+      "post": {
+        "operationId": "get_firewall_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "防火墙配置id列表",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "title": "GetFirewallListArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "获取安全设备详情",
+                      "items": {
+                        "$ref": "#/components/schemas/FirewallConfigDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetFirewallListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取安全设备配置",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/firewall/modify": {
+      "post": {
+        "operationId": "modify_firewall_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "addr": {
+                    "description": "三方设备地址",
+                    "title": "Addr",
+                    "type": "string"
+                  },
+                  "agent_ips": {
+                    "description": "牧云探针ip列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Agent Ips",
+                    "type": "array"
+                  },
+                  "api_token": {
+                    "default": "",
+                    "description": "三方设备api-token",
+                    "title": "Api Token",
+                    "type": "string"
+                  },
+                  "device_type": {
+                    "description": "设备类型",
+                    "title": "Device Type",
+                    "type": "integer"
+                  },
+                  "display_name": {
+                    "description": "设备名称",
+                    "title": "Display Name",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "设备id",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "password": {
+                    "default": "",
+                    "description": "三方设备登录密码",
+                    "title": "Password",
+                    "type": "string"
+                  },
+                  "remark": {
+                    "description": "备注",
+                    "title": "Remark",
+                    "type": "string"
+                  },
+                  "status": {
+                    "default": true,
+                    "description": "设备状态，true为启用，false为禁用",
+                    "title": "Status",
+                    "type": "boolean"
+                  },
+                  "username": {
+                    "default": "",
+                    "description": "三方设备登录用户名",
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "title": "UpdateFirewallArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/FirewallConfigDetail"
+                        }
+                      ],
+                      "description": "修改防火墙设备详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UpdateFirewallRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新安全设备配置",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/firewall/delete": {
+      "post": {
+        "operationId": "delete_firewall_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "设备id",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "DelFirewallArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "删除安全设备",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DelFirewallRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除防火墙设备配置",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/firewall/test": {
+      "post": {
+        "operationId": "test_send_firewall",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "防火墙配置模版id",
+                    "title": "Id",
+                    "type": "integer"
+                  }
+                },
+                "title": "FirewallTestArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "测试结果",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "FirewallTestRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "防火墙配置测试",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/alarm_email/get": {
+      "post": {
+        "operationId": "get_alarm_email",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "告警接收邮箱详情列表",
+                      "items": {
+                        "$ref": "#/components/schemas/AlarmEmailDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetAlarmEmailRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取邮箱配置列表",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/alarm_email/set": {
+      "post": {
+        "operationId": "set_alarm_email",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cc": {
+                    "default": [],
+                    "description": "抄送人列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Cc",
+                    "type": "array"
+                  },
+                  "email": {
+                    "description": "添加告警接收邮箱",
+                    "title": "Email",
+                    "type": "string"
+                  },
+                  "receive_daily_report": {
+                    "description": "是否订阅威胁感知统计日报",
+                    "title": "Receive Daily Report",
+                    "type": "boolean"
+                  },
+                  "receive_monthly_report": {
+                    "description": "是否订阅威胁感知统计月报",
+                    "title": "Receive Monthly Report",
+                    "type": "boolean"
+                  },
+                  "receive_weekly_report": {
+                    "description": "是否订阅威胁感知统计周报",
+                    "title": "Receive Weekly Report",
+                    "type": "boolean"
+                  },
+                  "receivers": {
+                    "description": "接收范围",
+                    "title": "Receivers",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email",
+                  "receive_monthly_report",
+                  "receive_weekly_report",
+                  "receive_daily_report",
+                  "receivers"
+                ],
+                "title": "SetAlarmEmailArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AlarmEmailDetail"
+                        }
+                      ],
+                      "description": "告警接收邮箱详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SetAlarmEmailRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "添加告警接收邮箱",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/alarm_email/update": {
+      "post": {
+        "operationId": "update_alarm_email",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cc": {
+                    "default": [],
+                    "description": "抄送人",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Cc",
+                    "type": "array"
+                  },
+                  "email": {
+                    "description": "告警接收邮箱地址",
+                    "title": "Email",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "要修改的告警接收邮箱id",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "receive_daily_report": {
+                    "description": "是否订阅威胁感知统计日报",
+                    "title": "Receive Daily Report",
+                    "type": "boolean"
+                  },
+                  "receive_monthly_report": {
+                    "description": "是否订阅威胁感知统计月报",
+                    "title": "Receive Monthly Report",
+                    "type": "boolean"
+                  },
+                  "receive_weekly_report": {
+                    "description": "是否订阅威胁感知统计周报",
+                    "title": "Receive Weekly Report",
+                    "type": "boolean"
+                  },
+                  "receivers": {
+                    "description": "接收范围",
+                    "title": "Receivers",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "email",
+                  "receivers",
+                  "receive_monthly_report",
+                  "receive_weekly_report",
+                  "receive_daily_report"
+                ],
+                "title": "UpdateAlarmEmailArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AlarmEmailDetail"
+                        }
+                      ],
+                      "description": "修改告警接收邮箱详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UpdateAlarmEmailRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改告警接收邮箱",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/email/batch_delete": {
+      "post": {
+        "operationId": "batch_delete_alarm_email",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id_list": {
+                    "default": [],
+                    "discription": "删除告警邮箱id列表",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Id List",
+                    "type": "array"
+                  }
+                },
+                "title": "DeleteAlarmEmailArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "是否成功删除告警接收邮箱",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DeleteAlarmEmailRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "批量删除告警接收邮箱",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/alarm_info/get": {
+      "post": {
+        "operationId": "get_alarm_info",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "告警事件类型列表",
+                      "items": {
+                        "$ref": "#/components/schemas/AlarmInfoDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetAlarmInfoRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取告警事件类型",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/rules/modify": {
+      "post": {
+        "operationId": "modify_alarm_rules",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_abnormal": {
+                    "description": "探针服务异常时发出通知",
+                    "title": "Agent Abnormal",
+                    "type": "boolean"
+                  },
+                  "agent_offline": {
+                    "description": "探针连接断开时发出警告",
+                    "title": "Agent Offline",
+                    "type": "boolean"
+                  },
+                  "agent_online": {
+                    "description": "探针连接恢复时发出通知",
+                    "title": "Agent Online",
+                    "type": "boolean"
+                  },
+                  "aggregation": {
+                    "default": false,
+                    "description": "是否开启汇总告警",
+                    "title": "Aggregation",
+                    "type": "boolean"
+                  },
+                  "alarm_agents": {
+                    "default": [],
+                    "description": "告警的探针范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Agents",
+                    "type": "array"
+                  },
+                  "alarm_groups": {
+                    "default": [],
+                    "description": "告警的业务组范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Groups",
+                    "type": "array"
+                  },
+                  "alarm_groups_tree": {
+                    "description": "告警的蜜罐范围树，用于前端显示",
+                    "items": {
+                      "type": "object"
+                    },
+                    "title": "Alarm Groups Tree",
+                    "type": "array"
+                  },
+                  "alarm_honeynets": {
+                    "default": [],
+                    "description": "告警的蜜网范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Honeynets",
+                    "type": "array"
+                  },
+                  "alarm_honeypots": {
+                    "default": [],
+                    "description": "告警的蜜罐范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Honeypots",
+                    "type": "array"
+                  },
+                  "alarm_threshold_time": {
+                    "default": 30,
+                    "description": "威胁告警汇总间隔",
+                    "minimum": 0,
+                    "title": "Alarm Threshold Time",
+                    "type": "integer"
+                  },
+                  "arp_event": {
+                    "description": "检测到ARP攻击时报告",
+                    "title": "Arp Event",
+                    "type": "boolean"
+                  },
+                  "connection_event": {
+                    "description": "检测到蜜罐入侵时报告",
+                    "title": "Connection Event",
+                    "type": "boolean"
+                  },
+                  "connection_event_risk_level": {
+                    "description": "蜜罐入侵事件的风险级别,1表示无威胁 2表示低危, 3表示中危, 4表示高危",
+                    "enum": [
+                      1,
+                      2,
+                      3,
+                      4
+                    ],
+                    "title": "Connection Event Risk Level",
+                    "type": "integer"
+                  },
+                  "cpu_threshold_time": {
+                    "description": "CPU使用率连续超过阈值且持续该时间长度后告警，以分钟为单位",
+                    "minimum": 0,
+                    "title": "Cpu Threshold Time",
+                    "type": "integer"
+                  },
+                  "cpu_threshold_usage": {
+                    "description": "CPU使用率阈值，为0时不告警",
+                    "minimum": 0,
+                    "title": "Cpu Threshold Usage",
+                    "type": "number"
+                  },
+                  "disk_threshold_usage": {
+                    "description": "磁盘占用率超过该阈值后告警，为0时不告警",
+                    "minimum": 0,
+                    "title": "Disk Threshold Usage",
+                    "type": "number"
+                  },
+                  "display_name": {
+                    "description": "告警配置模版名称",
+                    "title": "Display Name",
+                    "type": "string"
+                  },
+                  "email_config_ids": {
+                    "description": "邮箱ID列表",
+                    "items": {},
+                    "title": "Email Config Ids",
+                    "type": "array"
+                  },
+                  "enable": {
+                    "description": "是否开启告警模版",
+                    "title": "Enable",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "告警配置模版id",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "mem_threshold_time": {
+                    "description": "内存使用率连续超过阈值且持续该时间长度后告警，以分钟为单位",
+                    "minimum": 0,
+                    "title": "Mem Threshold Time",
+                    "type": "integer"
+                  },
+                  "mem_threshold_usage": {
+                    "description": "内存使用率阈值，为0时不告警",
+                    "minimum": 0,
+                    "title": "Mem Threshold Usage",
+                    "type": "number"
+                  },
+                  "ping_event": {
+                    "description": "检测到Ping扫描时报告",
+                    "title": "Ping Event",
+                    "type": "boolean"
+                  },
+                  "portrait": {
+                    "description": "获取攻击者画像时报告",
+                    "title": "Portrait",
+                    "type": "boolean"
+                  },
+                  "scanner_event": {
+                    "description": "检测到端口探测时报告",
+                    "title": "Scanner Event",
+                    "type": "boolean"
+                  },
+                  "smtp_config_id": {
+                    "description": "邮箱配置表ID",
+                    "title": "Smtp Config Id",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "模版类型，alert_popup弹窗告警，template告警模版",
+                    "title": "Type",
+                    "type": "string"
+                  },
+                  "user_role": {
+                    "description": "模版所属用户角色",
+                    "title": "User Role",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "模版所属用户",
+                    "title": "Username",
+                    "type": "string"
+                  },
+                  "webhook_config_id": {
+                    "description": "Webhook配置表ID",
+                    "format": "uuid",
+                    "title": "Webhook Config Id",
+                    "type": "string"
+                  }
+                },
+                "title": "AlarmRulesDetail",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "修改告警规则成功",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ModifyAlarmRulesRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改告警规则",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/rules/get": {
+      "post": {
+        "operationId": "get_alarm_rules",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_abnormal": {
+                    "description": "探针服务异常时发出通知",
+                    "title": "Agent Abnormal",
+                    "type": "boolean"
+                  },
+                  "agent_offline": {
+                    "description": "探针连接断开时发出警告",
+                    "title": "Agent Offline",
+                    "type": "boolean"
+                  },
+                  "agent_online": {
+                    "description": "探针连接恢复时发出通知",
+                    "title": "Agent Online",
+                    "type": "boolean"
+                  },
+                  "aggregation": {
+                    "default": false,
+                    "description": "是否开启汇总告警",
+                    "title": "Aggregation",
+                    "type": "boolean"
+                  },
+                  "alarm_agents": {
+                    "default": [],
+                    "description": "告警的探针范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Agents",
+                    "type": "array"
+                  },
+                  "alarm_groups": {
+                    "default": [],
+                    "description": "告警的业务组范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Groups",
+                    "type": "array"
+                  },
+                  "alarm_groups_tree": {
+                    "description": "告警的蜜罐范围树，用于前端显示",
+                    "items": {
+                      "type": "object"
+                    },
+                    "title": "Alarm Groups Tree",
+                    "type": "array"
+                  },
+                  "alarm_honeynets": {
+                    "default": [],
+                    "description": "告警的蜜网范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Honeynets",
+                    "type": "array"
+                  },
+                  "alarm_honeypots": {
+                    "default": [],
+                    "description": "告警的蜜罐范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Honeypots",
+                    "type": "array"
+                  },
+                  "alarm_threshold_time": {
+                    "default": 30,
+                    "description": "威胁告警汇总间隔",
+                    "minimum": 0,
+                    "title": "Alarm Threshold Time",
+                    "type": "integer"
+                  },
+                  "arp_event": {
+                    "description": "检测到ARP攻击时报告",
+                    "title": "Arp Event",
+                    "type": "boolean"
+                  },
+                  "connection_event": {
+                    "description": "检测到蜜罐入侵时报告",
+                    "title": "Connection Event",
+                    "type": "boolean"
+                  },
+                  "connection_event_risk_level": {
+                    "description": "蜜罐入侵事件的风险级别,1表示无威胁 2表示低危, 3表示中危, 4表示高危",
+                    "enum": [
+                      1,
+                      2,
+                      3,
+                      4
+                    ],
+                    "title": "Connection Event Risk Level",
+                    "type": "integer"
+                  },
+                  "cpu_threshold_time": {
+                    "description": "CPU使用率连续超过阈值且持续该时间长度后告警，以分钟为单位",
+                    "minimum": 0,
+                    "title": "Cpu Threshold Time",
+                    "type": "integer"
+                  },
+                  "cpu_threshold_usage": {
+                    "description": "CPU使用率阈值，为0时不告警",
+                    "minimum": 0,
+                    "title": "Cpu Threshold Usage",
+                    "type": "number"
+                  },
+                  "disk_threshold_usage": {
+                    "description": "磁盘占用率超过该阈值后告警，为0时不告警",
+                    "minimum": 0,
+                    "title": "Disk Threshold Usage",
+                    "type": "number"
+                  },
+                  "display_name": {
+                    "description": "告警配置模版名称",
+                    "title": "Display Name",
+                    "type": "string"
+                  },
+                  "email_config_ids": {
+                    "description": "邮箱ID列表",
+                    "items": {},
+                    "title": "Email Config Ids",
+                    "type": "array"
+                  },
+                  "enable": {
+                    "description": "是否开启告警模版",
+                    "title": "Enable",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "告警配置模版id",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "mem_threshold_time": {
+                    "description": "内存使用率连续超过阈值且持续该时间长度后告警，以分钟为单位",
+                    "minimum": 0,
+                    "title": "Mem Threshold Time",
+                    "type": "integer"
+                  },
+                  "mem_threshold_usage": {
+                    "description": "内存使用率阈值，为0时不告警",
+                    "minimum": 0,
+                    "title": "Mem Threshold Usage",
+                    "type": "number"
+                  },
+                  "ping_event": {
+                    "description": "检测到Ping扫描时报告",
+                    "title": "Ping Event",
+                    "type": "boolean"
+                  },
+                  "portrait": {
+                    "description": "获取攻击者画像时报告",
+                    "title": "Portrait",
+                    "type": "boolean"
+                  },
+                  "scanner_event": {
+                    "description": "检测到端口探测时报告",
+                    "title": "Scanner Event",
+                    "type": "boolean"
+                  },
+                  "smtp_config_id": {
+                    "description": "邮箱配置表ID",
+                    "title": "Smtp Config Id",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "模版类型，alert_popup弹窗告警，template告警模版",
+                    "title": "Type",
+                    "type": "string"
+                  },
+                  "user_role": {
+                    "description": "模版所属用户角色",
+                    "title": "User Role",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "模版所属用户",
+                    "title": "Username",
+                    "type": "string"
+                  },
+                  "webhook_config_id": {
+                    "description": "Webhook配置表ID",
+                    "format": "uuid",
+                    "title": "Webhook Config Id",
+                    "type": "string"
+                  }
+                },
+                "title": "GetAlarmRulesArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "告警规则的详细内容",
+                      "items": {
+                        "$ref": "#/components/schemas/AlarmRulesDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetAlarmRulesRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取告警模版配置",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/rules/delete": {
+      "post": {
+        "operationId": "alarm_rules_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "待删除告警模版id",
+                    "title": "Id",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "AlarmRulesDelArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "删除告警模版结果",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AlarmRulesDelRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除告警模版配置",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/rules/set": {
+      "post": {
+        "operationId": "setalarm_rules",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_abnormal": {
+                    "description": "探针服务异常时发出通知",
+                    "title": "Agent Abnormal",
+                    "type": "boolean"
+                  },
+                  "agent_offline": {
+                    "description": "探针连接断开时发出警告",
+                    "title": "Agent Offline",
+                    "type": "boolean"
+                  },
+                  "agent_online": {
+                    "description": "探针连接恢复时发出通知",
+                    "title": "Agent Online",
+                    "type": "boolean"
+                  },
+                  "aggregation": {
+                    "default": false,
+                    "description": "是否开启汇总告警",
+                    "title": "Aggregation",
+                    "type": "boolean"
+                  },
+                  "alarm_agents": {
+                    "default": [],
+                    "description": "告警的探针范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Agents",
+                    "type": "array"
+                  },
+                  "alarm_groups": {
+                    "default": [],
+                    "description": "告警的业务组范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Groups",
+                    "type": "array"
+                  },
+                  "alarm_groups_tree": {
+                    "description": "告警的蜜罐范围树，用于前端显示",
+                    "items": {
+                      "type": "object"
+                    },
+                    "title": "Alarm Groups Tree",
+                    "type": "array"
+                  },
+                  "alarm_honeynets": {
+                    "default": [],
+                    "description": "告警的蜜网范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Honeynets",
+                    "type": "array"
+                  },
+                  "alarm_honeypots": {
+                    "default": [],
+                    "description": "告警的蜜罐范围",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Honeypots",
+                    "type": "array"
+                  },
+                  "alarm_threshold_time": {
+                    "default": 30,
+                    "description": "威胁告警汇总间隔",
+                    "minimum": 0,
+                    "title": "Alarm Threshold Time",
+                    "type": "integer"
+                  },
+                  "arp_event": {
+                    "description": "检测到ARP攻击时报告",
+                    "title": "Arp Event",
+                    "type": "boolean"
+                  },
+                  "connection_event": {
+                    "description": "检测到蜜罐入侵时报告",
+                    "title": "Connection Event",
+                    "type": "boolean"
+                  },
+                  "connection_event_risk_level": {
+                    "description": "蜜罐入侵事件的风险级别,1表示无威胁 2表示低危, 3表示中危, 4表示高危",
+                    "enum": [
+                      1,
+                      2,
+                      3,
+                      4
+                    ],
+                    "title": "Connection Event Risk Level",
+                    "type": "integer"
+                  },
+                  "cpu_threshold_time": {
+                    "description": "CPU使用率连续超过阈值且持续该时间长度后告警，以分钟为单位",
+                    "minimum": 0,
+                    "title": "Cpu Threshold Time",
+                    "type": "integer"
+                  },
+                  "cpu_threshold_usage": {
+                    "description": "CPU使用率阈值，为0时不告警",
+                    "minimum": 0,
+                    "title": "Cpu Threshold Usage",
+                    "type": "number"
+                  },
+                  "disk_threshold_usage": {
+                    "description": "磁盘占用率超过该阈值后告警，为0时不告警",
+                    "minimum": 0,
+                    "title": "Disk Threshold Usage",
+                    "type": "number"
+                  },
+                  "display_name": {
+                    "description": "告警配置模版名称",
+                    "title": "Display Name",
+                    "type": "string"
+                  },
+                  "email_config_ids": {
+                    "description": "邮箱ID列表",
+                    "items": {},
+                    "title": "Email Config Ids",
+                    "type": "array"
+                  },
+                  "enable": {
+                    "description": "是否开启告警模版",
+                    "title": "Enable",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "告警配置模版id",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "mem_threshold_time": {
+                    "description": "内存使用率连续超过阈值且持续该时间长度后告警，以分钟为单位",
+                    "minimum": 0,
+                    "title": "Mem Threshold Time",
+                    "type": "integer"
+                  },
+                  "mem_threshold_usage": {
+                    "description": "内存使用率阈值，为0时不告警",
+                    "minimum": 0,
+                    "title": "Mem Threshold Usage",
+                    "type": "number"
+                  },
+                  "ping_event": {
+                    "description": "检测到Ping扫描时报告",
+                    "title": "Ping Event",
+                    "type": "boolean"
+                  },
+                  "portrait": {
+                    "description": "获取攻击者画像时报告",
+                    "title": "Portrait",
+                    "type": "boolean"
+                  },
+                  "scanner_event": {
+                    "description": "检测到端口探测时报告",
+                    "title": "Scanner Event",
+                    "type": "boolean"
+                  },
+                  "smtp_config_id": {
+                    "description": "邮箱配置表ID",
+                    "title": "Smtp Config Id",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "模版类型，alert_popup弹窗告警，template告警模版",
+                    "title": "Type",
+                    "type": "string"
+                  },
+                  "user_role": {
+                    "description": "模版所属用户角色",
+                    "title": "User Role",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "模版所属用户",
+                    "title": "Username",
+                    "type": "string"
+                  },
+                  "webhook_config_id": {
+                    "description": "Webhook配置表ID",
+                    "format": "uuid",
+                    "title": "Webhook Config Id",
+                    "type": "string"
+                  }
+                },
+                "title": "SetAlarmRulesArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AlarmRulesDetail"
+                        }
+                      ],
+                      "description": "创建告警模版",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SetAlarmRulesRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建/修改告警模版配置",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/ip_whitelist/list": {
+      "post": {
+        "operationId": "list_email_ip_white_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  }
+                },
+                "title": "ListEmailIPWhiteListArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "description": "实际返回的数据",
+                      "items": {
+                        "$ref": "#/components/schemas/EmailIPWhiteListDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "total": {
+                      "description": "满足条件的记录总数",
+                      "minimum": 0,
+                      "title": "Total",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "data"
+                  ],
+                  "title": "ListEmailIPWhiteListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "告警白名单列表",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/ip_whitelist/batch_create": {
+      "post": {
+        "operationId": "batch_create_email_ip_white_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "apply_user": {
+                    "description": "生效用户",
+                    "enum": [
+                      "only_me",
+                      "all"
+                    ],
+                    "title": "Apply User"
+                  },
+                  "from_mc": {
+                    "default": false,
+                    "description": "为True时，来自集中管理平台，不可编辑",
+                    "title": "From Mc",
+                    "type": "boolean"
+                  },
+                  "handle": {
+                    "default": "access",
+                    "description": "access表示可访问蜜罐但不记录日志，reject表示不可访问蜜罐",
+                    "title": "Handle",
+                    "type": "string"
+                  },
+                  "remark_text": {
+                    "description": "备注",
+                    "title": "Remark Text",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "换行分隔。每行第一个分号前表示源 IP 与端口；第一个分\n号到第二个分号之间表示目的 IP 与端口；第二个分号后表\n示协议，留空表示全部。例:\n192.168.10.12\n192.168.10.12;192.168.10.13;tcp\n;192.168.10.12;udp\n192.168.10.13;;icmp\n192.168.10.1/16:80-88;192.168.11.1/16:80-88;tcp\nfe80::52cf\n[fe80::52cf]:80;[fe80::52cf]:88;tcp",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Rules",
+                    "type": "array"
+                  },
+                  "save_event": {
+                    "default": true,
+                    "description": "为True时，对符合这条白名单配置的内容进行记录",
+                    "title": "Save Event",
+                    "type": "boolean"
+                  },
+                  "send_email": {
+                    "default": true,
+                    "description": "为True时，对符合这条白名单配置的内容进行邮件告警",
+                    "title": "Send Email",
+                    "type": "boolean"
+                  },
+                  "send_syslog": {
+                    "default": true,
+                    "description": "为True时，对符合这条白名单配置的内容发送syslog",
+                    "title": "Send Syslog",
+                    "type": "boolean"
+                  },
+                  "uuids": {
+                    "description": "预设uuid， 用于集中管理平台",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Uuids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "rules",
+                  "apply_user"
+                ],
+                "title": "BatchCreateEmailIPWhiteListArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created": {
+                      "description": "新创建的记录数",
+                      "minimum": 0,
+                      "title": "Created",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ],
+                  "title": "BatchCreateEmailIPWhiteListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "批量创建告警白名单",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/ip_whitelist/update": {
+      "post": {
+        "operationId": "update_whitelist",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "apply_user": {
+                    "description": "生效用户",
+                    "enum": [
+                      "only_me",
+                      "all"
+                    ],
+                    "title": "Apply User"
+                  },
+                  "from_addr": {
+                    "description": "来源IP，形如“1.1.1.1/24”、“1.1.1.1”",
+                    "title": "From Addr",
+                    "type": "string"
+                  },
+                  "from_port": {
+                    "description": "来源端口，形如“1-10,22,200-2000,5432”",
+                    "title": "From Port",
+                    "type": "string"
+                  },
+                  "handle": {
+                    "default": "access",
+                    "description": "access表示可访问蜜罐但不记录日志，reject表示不可访问蜜罐",
+                    "title": "Handle",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "待修改的白名单ID",
+                    "format": "uuid",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "protocol": {
+                    "default": "",
+                    "description": "白名单针对的协议，形如“tcp”、“”、“udp”、“icmp”",
+                    "title": "Protocol",
+                    "type": "string"
+                  },
+                  "remark_text": {
+                    "description": "备注",
+                    "title": "Remark Text",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "换行分隔。每行第一个分号前表示源 IP 与端口；第一个分\n    号到第二个分号之间表示目的 IP 与端口；第二个分号后表\n    示协议，留空表示全部。例:\n    192.168.10.12\n    192.168.10.12;192.168.10.13;tcp\n    ;192.168.10.12;udp\n    192.168.10.13;;icmp\n    192.168.10.1/16:80-88;192.168.11.1/16:80-88;tcp\n    fe80::52cf\n    [fe80::52cf]:80;[fe80::52cf]:88;tcp",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Rules",
+                    "type": "array"
+                  },
+                  "save_event": {
+                    "default": true,
+                    "description": "为True时，对符合这条白名单配置的内容进行记录",
+                    "title": "Save Event",
+                    "type": "boolean"
+                  },
+                  "send_email": {
+                    "default": true,
+                    "description": "为True时，对符合这条白名单配置的内容进行邮件告警",
+                    "title": "Send Email",
+                    "type": "boolean"
+                  },
+                  "send_syslog": {
+                    "default": true,
+                    "description": "为True时，对符合这条白名单配置的内容发送syslog",
+                    "title": "Send Syslog",
+                    "type": "boolean"
+                  },
+                  "to_addr": {
+                    "description": "目的IP，形如“1.1.1.1/24”、“1.1.1.1”",
+                    "title": "To Addr",
+                    "type": "string"
+                  },
+                  "to_port": {
+                    "description": "目的端口，形如“1-10,22,200-2000,5432”",
+                    "title": "To Port",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "rules",
+                  "apply_user"
+                ],
+                "title": "UpdateEmailWhitelistArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "UpdateEmailWhitelistRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改告警白名单",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/ip_whitelist/delete": {
+      "post": {
+        "operationId": "delete_whitelist",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "删除白名单id列表",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "WhitelistDeleteArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "白名单是否删除成功",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "WhitelistDeleteRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除白名单",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/system_alarm/notifer": {
+      "post": {
+        "operationId": "system_alarm_notifer",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "unit": {
+                    "default": "60",
+                    "description": "默认为60s",
+                    "title": "Unit",
+                    "type": "string"
+                  }
+                },
+                "title": "SystemAlarmNotiferArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "系统告警列表",
+                      "items": {
+                        "$ref": "#/components/schemas/SystemAlarmDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    }
+                  },
+                  "title": "SystemAlarmNotiferRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "系统告警列表",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/sms_alarm_config/get": {
+      "post": {
+        "operationId": "get_sms_alarm_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "webhook模版id(uuid)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "title": "GetSmsAlarmArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "获取Webhook配置信息",
+                      "items": {},
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "Webhook告警配置错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "Webhook告警配置失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetSmsAlarmRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取Webhook配置信息",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/sms_alarm_config/put": {
+      "post": {
+        "operationId": "update_sms_alarm_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "display_name": {
+                    "description": "webhook模版名称",
+                    "title": "Display Name",
+                    "type": "string"
+                  },
+                  "encode": {
+                    "description": "编码格式",
+                    "title": "Encode",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "更新webhook配置信息",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "告警消息",
+                    "title": "Message",
+                    "type": "string"
+                  },
+                  "param_type": {
+                    "description": "请求参数类型, json 或 string，xml",
+                    "enum": [
+                      "string",
+                      "json",
+                      "xml"
+                    ],
+                    "title": "Param Type",
+                    "type": "string"
+                  },
+                  "url": {
+                    "description": "请求的url",
+                    "title": "Url",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "模版所属用户",
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "url",
+                  "param_type",
+                  "message"
+                ],
+                "title": "UpdateSmsEmailConfigArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/SmsAlarmDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "设置Webhook告警的配置信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "设置Webhook告警配置错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "设置Webhook告警配置失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UpdateSmsEmailConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "设置Webhook告警的配置信息",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/sms_alarm_config/test": {
+      "post": {
+        "operationId": "send_sms_test",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "webhook配置id",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "SendSmsArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": "",
+                      "description": "如果成功data 为success, 失败为空",
+                      "title": "Data",
+                      "type": "string"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "Webhook测试失败的描述",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "Webhook测试的详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SendSmsRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "Webhook告警配置测试",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/alarm/sms_alarm_config/delete": {
+      "post": {
+        "operationId": "sms_config_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "待删除webhook配置的ids列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "SmsConfigDeleteArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "Webhook配置删除的响应结果",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "Webhook配置删除失败的描述",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "Webhook配置删除的详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SmsConfigDeleteRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除Webhook告警配置",
+        "tags": [
+          "告警配置"
+        ]
+      }
+    },
+    "/api/honey/net/change": {
+      "post": {
+        "operationId": "honeynet_change",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "honeynet_id": {
+                    "description": "蜜网ID",
+                    "title": "Honeynet Id",
+                    "type": "string"
+                  },
+                  "honeypot_ids": {
+                    "description": "蜜罐ID列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "honeypot_ids",
+                  "honeynet_id"
+                ],
+                "title": "ChangeHoneynetArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更改蜜罐蜜网",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/net/get_all_honey": {
+      "post": {
+        "operationId": "get_all_honey",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "获取蜜网蜜罐信息",
+                      "items": {
+                        "type": "object"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetAllHoneyRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取蜜网蜜罐信息",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/pot/create": {
+      "post": {
+        "operationId": "honeypot_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "display_name": {
+                    "description": "蜜罐名称",
+                    "title": "Display Name",
+                    "type": "string"
+                  },
+                  "image": {
+                    "description": "镜像名称，比如wiki",
+                    "title": "Image",
+                    "type": "string"
+                  },
+                  "image_id": {
+                    "description": "镜像的id",
+                    "title": "Image Id",
+                    "type": "string"
+                  },
+                  "nid": {
+                    "description": "蜜网ID",
+                    "title": "Nid",
+                    "type": "string"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "preset": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/CreateHoneypotPresetBaseArg"
+                      }
+                    ],
+                    "description": "模版相关信息",
+                    "title": "Preset"
+                  }
+                },
+                "required": [
+                  "nid",
+                  "image",
+                  "image_id",
+                  "display_name"
+                ],
+                "title": "CreateHoneypotArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/HoneypotBaseItem"
+                        }
+                      ],
+                      "description": "蜜罐信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "CreateHoneypotRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建蜜罐",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/pot/list": {
+      "post": {
+        "operationId": "honeypot_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "honey_net": {
+                    "description": "蜜网ID，字符串为空时不对此项做筛选",
+                    "title": "Honey Net",
+                    "type": "string"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  }
+                },
+                "title": "HoneypotListArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": "",
+                      "description": "蜜罐的详细信息",
+                      "items": {
+                        "$ref": "#/components/schemas/HoneypotListDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误信息详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "HoneypotListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "蜜罐列表",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/pot/upgrade": {
+      "post": {
+        "operationId": "honeypot_upgrade",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cids": {
+                    "description": "蜜罐ID",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Cids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "cids"
+                ],
+                "title": "HoneypotUpgradeArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "升级蜜罐",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/pot/start": {
+      "post": {
+        "operationId": "honeypot_start",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cids": {
+                    "default": [],
+                    "description": "蜜罐ID列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Cids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  }
+                },
+                "title": "HoneypotStartArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": {},
+                      "description": "蜜罐启动的结果",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误信息详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "HoneypotStartRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "启动蜜罐",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/pot/stop": {
+      "post": {
+        "operationId": "honeypot_stop",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cids": {
+                    "default": [],
+                    "description": "蜜罐ID列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Cids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  }
+                },
+                "title": "HoneypotStopArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": {},
+                      "description": "蜜罐停止的结果",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误信息详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "HoneypotStopRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "停止蜜罐",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/pot/reset": {
+      "post": {
+        "operationId": "honeypot_reset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cids": {
+                    "default": [],
+                    "description": "蜜罐ID列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Cids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "preset": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/CreateHoneypotPresetBaseArg"
+                      }
+                    ],
+                    "default": {},
+                    "description": "模版相关信息（重置不传，无模版传None）",
+                    "title": "Preset"
+                  }
+                },
+                "title": "ResetHoneypotArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": {},
+                      "description": "重置蜜罐信息",
+                      "title": "Data",
+                      "type": "object"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误信息详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ResetHoneypotRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "重置蜜罐",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/pot/config/set": {
+      "post": {
+        "operationId": "honeypot_config_set",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cycle": {
+                    "default": 0,
+                    "description": "周期",
+                    "title": "Cycle",
+                    "type": "integer"
+                  }
+                },
+                "title": "HoneypotConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "定时重置蜜罐设置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "HoneypotConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "定时重置蜜罐配置",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/pot/config/get": {
+      "post": {
+        "operationId": "honeypot_config_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/HoneypotConfigDetail"
+                        }
+                      ],
+                      "description": "定时重置蜜罐配置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetHoneypotConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取定时重置蜜罐配置",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/pot/preset/change": {
+      "post": {
+        "operationId": "honeypot_change_preset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cid": {
+                    "description": "蜜罐ID",
+                    "title": "Cid",
+                    "type": "string"
+                  },
+                  "preset": {
+                    "description": "模版ID",
+                    "title": "Preset",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cid",
+                  "preset"
+                ],
+                "title": "HoneypotChangePresetArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更换蜜罐模版",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/preset/upload": {
+      "post": {
+        "operationId": "preset_upload",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "copy_preset": {
+                    "description": "复制模版的ID",
+                    "title": "Copy Preset",
+                    "type": "string"
+                  },
+                  "meta": {
+                    "description": "模版信息（蜜罐中template的信息）",
+                    "title": "Meta",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "镜像名称",
+                    "title": "Name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "meta"
+                ],
+                "title": "UploadPresetArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PresetData"
+                        }
+                      ],
+                      "description": "上传模版返回信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UploadPresetRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "上传模版",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/preset/delete": {
+      "post": {
+        "operationId": "preset_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "description": "蜜罐镜像",
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "preset": {
+                    "description": "模版ID",
+                    "title": "Preset",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "preset"
+                ],
+                "title": "DeletePresetArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DeletePresetRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除模版",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/preset/fetch": {
+      "post": {
+        "operationId": "preset_fetch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "preset": {
+                    "description": "模版ID",
+                    "title": "Preset",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "preset"
+                ],
+                "title": "FetchPresetArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/FetchPresetData"
+                        }
+                      ],
+                      "description": "上传模版返回信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "FetchPresetRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取模版信息",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/generate_git": {
+      "post": {
+        "operationId": "generate_git_bait",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_address": {
+                    "description": "诱饵所指向的探针地址，必须为主机名或IP",
+                    "title": "Agent Address",
+                    "type": "string"
+                  },
+                  "bait_readme": {
+                    "description": "诱饵所展示的项目说明，MarkDown格式",
+                    "title": "Bait Readme",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "agent_address"
+                ],
+                "title": "GenerateGitBaitArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "meta_id": {
+                      "description": "GIT诱饵信息的ID",
+                      "format": "uuid",
+                      "title": "Meta Id",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "meta_id"
+                  ],
+                  "title": "GenerateGitBaitRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "根据给定参数生成一个 GIT 诱饵",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/generate_host": {
+      "post": {
+        "operationId": "generate_host_bait",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_info_list": {
+                    "description": "探针地址信息",
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "title": "Agent Info List",
+                    "type": "array"
+                  },
+                  "bait_type": {
+                    "description": "诱饵的类型",
+                    "enum": [
+                      "bash_history",
+                      "hostname",
+                      "public_key",
+                      "rdp",
+                      "login_credentials"
+                    ],
+                    "title": "Bait Type"
+                  }
+                },
+                "required": [
+                  "bait_type",
+                  "agent_info_list"
+                ],
+                "title": "GenerateHostBaitArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "script": {
+                      "description": "服务端生成的诱饵配置脚本",
+                      "title": "Script",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "script"
+                  ],
+                  "title": "GenerateHostBaitRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "根据给定参数生成一个主机诱饵",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/email/list": {
+      "post": {
+        "operationId": "bait_email_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  }
+                },
+                "title": "EmailBaitListArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "EmailBaitItemListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "邮件诱饵列表",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/email/detail": {
+      "post": {
+        "operationId": "bait_email_detail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "诱饵id",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "EmailBaitDetailArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/EmailBaitDetail"
+                        }
+                      ],
+                      "description": "诱饵详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "EmailBaitDetailRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "邮件诱饵详情",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/email/delete": {
+      "post": {
+        "operationId": "bait_email_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "ID列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "EmailBaitDeleteArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除邮件诱饵",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/email/apply": {
+      "post": {
+        "operationId": "bait_email_apply",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "邮件诱饵ID",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "EmailBaitApplyArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "发送邮件诱饵",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/email/scene/list": {
+      "post": {
+        "operationId": "list_bait_email_scene_list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": "",
+                      "description": "场景列表",
+                      "items": {
+                        "$ref": "#/components/schemas/ListScriptSceneItem"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误信息详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ListScriptSceneRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取剧本列表",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/aws/generate": {
+      "post": {
+        "operationId": "generate_bait_aws",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "aws_access_key_id": {
+                    "description": "aws access key id",
+                    "title": "Aws Access Key Id",
+                    "type": "string"
+                  },
+                  "aws_secret_access_key": {
+                    "description": "aws secret access key",
+                    "title": "Aws Secret Access Key",
+                    "type": "string"
+                  },
+                  "http_proxy": {
+                    "default": "",
+                    "description": "http代理",
+                    "title": "Http Proxy",
+                    "type": "string"
+                  },
+                  "id": {
+                    "default": "",
+                    "description": "aws诱饵id",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "is_admin": {
+                    "default": true,
+                    "description": "是否主账号",
+                    "title": "Is Admin",
+                    "type": "boolean"
+                  },
+                  "region": {
+                    "default": "",
+                    "description": "aws区域",
+                    "title": "Region",
+                    "type": "string"
+                  },
+                  "remark": {
+                    "default": "",
+                    "description": "备注",
+                    "title": "Remark",
+                    "type": "string"
+                  }
+                },
+                "title": "GenerateBaitAwsArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成aws诱饵账号",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/aws/init": {
+      "post": {
+        "operationId": "init_bait_aws",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "初始化aws诱饵账号",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/aws/destroy": {
+      "post": {
+        "operationId": "destroy_bait_aws",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "aws诱饵id",
+                    "format": "uuid",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "DeleteBaitAwsArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "销毁aws诱饵账号",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/aws/detail": {
+      "post": {
+        "operationId": "get_bait_aws_account_detail",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AwsBaitAccountDetail"
+                        }
+                      ],
+                      "default": {},
+                      "description": "账户详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetBaitAwsRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "aws诱饵账号详情",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/aws/delete": {
+      "post": {
+        "operationId": "delete_bait_aws_account",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "aws诱饵id",
+                    "format": "uuid",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "DeleteBaitAwsArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除aws诱账号",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/bait/aws/update": {
+      "post": {
+        "operationId": "update_bait_aws_account",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "aws诱饵id",
+                    "format": "uuid",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "remark": {
+                    "default": "",
+                    "description": "备注",
+                    "title": "Remark",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "UpdateBaitAwsArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新子aws诱饵账号",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/cert/list": {
+      "post": {
+        "operationId": "cert_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "CertListArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "证书列表",
+                      "items": {
+                        "$ref": "#/components/schemas/CertDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "CertListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "查看web蜜罐证书",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/cert/delete": {
+      "post": {
+        "operationId": "cert_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "证书id",
+                    "format": "uuid",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "CertDeleteArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除web蜜罐证书",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/set_xff": {
+      "post": {
+        "operationId": "set_xff",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "xff_enable": {
+                    "description": "是否启用",
+                    "title": "Xff Enable",
+                    "type": "boolean"
+                  },
+                  "xff_index": {
+                    "description": "第几个IP（暂时不做）",
+                    "title": "Xff Index",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "xff_enable"
+                ],
+                "title": "SetXffArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "更新xff返回",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SetXffRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "设置 Web 蜜罐源 IP 获取方式",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/get_xff": {
+      "post": {
+        "operationId": "get_xff",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/SetXffArg"
+                        }
+                      ],
+                      "description": "data",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetXffRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取 Web 蜜罐源 IP 获取方式",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/system_mem/get": {
+      "post": {
+        "operationId": "get_system_mem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "GetSystemMemArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/SystemStatusDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "系统内存占用",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误信息详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetSystemMemRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "系统内存占用",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/script/create": {
+      "post": {
+        "operationId": "create_honeynet_script",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "description": {
+                    "default": "",
+                    "description": "模板描述",
+                    "maxLength": 1000,
+                    "minLength": 0,
+                    "title": "Description",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "模板ID",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "模板名称",
+                    "maxLength": 40,
+                    "minLength": 1,
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "title": "CreateHoneynetScriptArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/HoneynetScriptDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "模板信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误信息详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "CreateHoneynetScriptRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建蜜网剧本模板",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/script/update": {
+      "post": {
+        "operationId": "update_honeynet_script",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "description": {
+                    "default": "",
+                    "description": "模板描述",
+                    "maxLength": 1000,
+                    "minLength": 0,
+                    "title": "Description",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "模板ID",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "模板名称",
+                    "maxLength": 40,
+                    "minLength": 1,
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "title": "CreateHoneynetScriptArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新蜜网剧本模板",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/script/delete": {
+      "post": {
+        "operationId": "delete_honeynet_script",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "模板ID列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "DeleteHoneynetScriptArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除蜜网剧本模板",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/script/list": {
+      "post": {
+        "operationId": "list_honeynet_script",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  }
+                },
+                "title": "ListHoneynetScriptArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": "",
+                      "description": "模板信息列表",
+                      "items": {
+                        "$ref": "#/components/schemas/HoneynetScriptDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误信息详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ListHoneynetScriptRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "蜜网剧本服务列表",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/script/apply": {
+      "post": {
+        "operationId": "apply_honeynet_script",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "honeynet_id": {
+                    "description": "蜜网ID",
+                    "minLength": 1,
+                    "title": "Honeynet Id",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "模板ID",
+                    "title": "Id",
+                    "type": "string"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "port_maps": {
+                    "default": [],
+                    "description": "服务列表",
+                    "items": {
+                      "items": {
+                        "$ref": "#/components/schemas/PortmapData"
+                      },
+                      "type": "array"
+                    },
+                    "title": "Port Maps",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "honeynet_id"
+                ],
+                "title": "ApplyHoneynetScriptArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "应用蜜网剧本模板",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/script/service/update": {
+      "post": {
+        "operationId": "update_honeynet_script_service",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "port_maps": {
+                    "description": "添加/更新探针对应服务的列表",
+                    "items": {
+                      "$ref": "#/components/schemas/Portmaps"
+                    },
+                    "title": "Port Maps",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "port_maps"
+                ],
+                "title": "UpdateScriptServiceArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新蜜网剧本服务",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/honey/script/service/delete": {
+      "post": {
+        "operationId": "delete_honeynet_script_service",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node": {
+                    "description": "节点的sn",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "port_maps": {
+                    "additionalProperties": {
+                      "items": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "default": {},
+                    "description": "模板ID和服务ID的映射",
+                    "title": "Port Maps",
+                    "type": "object"
+                  }
+                },
+                "title": "DeleteScriptServiceArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除蜜网剧本服务",
+        "tags": [
+          "蜜罐管理"
+        ]
+      }
+    },
+    "/api/event/detail": {
+      "post": {
+        "operationId": "get_connection",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "brief": {
+                    "default": false,
+                    "description": "简明返回",
+                    "title": "Brief",
+                    "type": "boolean"
+                  },
+                  "connection_id": {
+                    "description": "连接的ID",
+                    "format": "uuid",
+                    "title": "Connection Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "connection_id"
+                ],
+                "title": "GetConnectionArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ConnectionDetail"
+                        }
+                      ],
+                      "description": "蜜罐入侵的详细信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "获取蜜罐入侵详细信息失败描述",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "获取蜜罐入侵详细信息失败详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetConnectionRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取蜜罐入侵日志的详细信息",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/list": {
+      "post": {
+        "operationId": "list_connection",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "connection_ids": {
+                    "default": [],
+                    "description": "连接ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Connection Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": {},
+                    "description": "蜜罐事件类型字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Event Types",
+                    "type": "object"
+                  },
+                  "honeypot_ids": {
+                    "default": [],
+                    "description": "蜜罐ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "connection ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "portrait_id": {
+                    "default": [],
+                    "description": "溯源numID列表，为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Portrait Id",
+                    "type": "array"
+                  },
+                  "proto": {
+                    "description": "连接协议，如'tcp'、'udp'",
+                    "title": "Proto",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  },
+                  "webshell_id": {
+                    "description": "Webshell的ID，为空时不对此项做过滤",
+                    "title": "Webshell Id",
+                    "type": "string"
+                  }
+                },
+                "title": "FilterConnectionArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "FilterConnectionRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "蜜罐入侵日志列表",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/scanner/detail": {
+      "post": {
+        "operationId": "scanner_event_detail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "enable_preview": {
+                    "description": "当dest_port的文本长度超过某个阈值时，将其展示为形如“100-200, 22等34个端口”的形式",
+                    "title": "Enable Preview",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "所需端口探测日志的ID",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "enable_preview"
+                ],
+                "title": "ScannerEventMsgArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ScannerEventMsg"
+                        }
+                      ],
+                      "description": "获取端口探测日志的详细信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ScannerEventMsgRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取端口探测日志的详细信息",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/scanner/list": {
+      "post": {
+        "operationId": "list_scanner_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "dest_ips": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ips",
+                    "type": "object"
+                  },
+                  "dest_port_ranges": {
+                    "default": {},
+                    "description": "目标端口区间列表，列表为空时不对该项进行筛选",
+                    "title": "Dest Port Ranges",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "扫描事件ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "protocols": {
+                    "default": [],
+                    "description": "扫描事件协议，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        "tcp",
+                        "udp"
+                      ]
+                    },
+                    "title": "Protocols",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  }
+                },
+                "title": "ListScannerEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "ListScannerEventRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "端口探测日志列表",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/scanner/delete": {
+      "post": {
+        "operationId": "delete_scanner_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "dest_ips": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ips",
+                    "type": "object"
+                  },
+                  "dest_port_ranges": {
+                    "default": {},
+                    "description": "目标端口区间列表，列表为空时不对该项进行筛选",
+                    "title": "Dest Port Ranges",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "扫描事件ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "protocols": {
+                    "default": [],
+                    "description": "扫描事件协议，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        "tcp",
+                        "udp"
+                      ]
+                    },
+                    "title": "Protocols",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  }
+                },
+                "title": "DeleteScannerEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "删除端口探测日志",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DeleteScannerEventRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除端口探测日志",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/scanner/download_token": {
+      "post": {
+        "operationId": "generate_scanner_download_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于扫描事件的统一筛选参数\n\n警告: dest_port_ranges字段不为空列表时，会发生一次成本可能不可忽略的数据库查询",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "dest_ips": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ips",
+                    "type": "object"
+                  },
+                  "dest_port_ranges": {
+                    "default": {},
+                    "description": "目标端口区间列表，列表为空时不对该项进行筛选",
+                    "title": "Dest Port Ranges",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "扫描事件ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "protocols": {
+                    "default": [],
+                    "description": "扫描事件协议，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        "tcp",
+                        "udp"
+                      ]
+                    },
+                    "title": "Protocols",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  }
+                },
+                "title": "ScannerEventFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetScannerId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetScannerIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成json格式端口探测日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/scanner/download_csv_token": {
+      "post": {
+        "operationId": "generate_scanner_download_csv_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于扫描事件的统一筛选参数\n\n警告: dest_port_ranges字段不为空列表时，会发生一次成本可能不可忽略的数据库查询",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "dest_ips": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ips",
+                    "type": "object"
+                  },
+                  "dest_port_ranges": {
+                    "default": {},
+                    "description": "目标端口区间列表，列表为空时不对该项进行筛选",
+                    "title": "Dest Port Ranges",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "扫描事件ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "protocols": {
+                    "default": [],
+                    "description": "扫描事件协议，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        "tcp",
+                        "udp"
+                      ]
+                    },
+                    "title": "Protocols",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  }
+                },
+                "title": "ScannerEventFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetScannerId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetScannerIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成scv格式端口探测日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/scanner/download_excel_token": {
+      "post": {
+        "operationId": "generate_scanner_download_excel_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于扫描事件的统一筛选参数\n\n警告: dest_port_ranges字段不为空列表时，会发生一次成本可能不可忽略的数据库查询",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "dest_ips": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ips",
+                    "type": "object"
+                  },
+                  "dest_port_ranges": {
+                    "default": {},
+                    "description": "目标端口区间列表，列表为空时不对该项进行筛选",
+                    "title": "Dest Port Ranges",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "扫描事件ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "protocols": {
+                    "default": [],
+                    "description": "扫描事件协议，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        "tcp",
+                        "udp"
+                      ]
+                    },
+                    "title": "Protocols",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  }
+                },
+                "title": "ScannerEventFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetScannerId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetScannerIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成excel格式端口探测日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/delete": {
+      "post": {
+        "operationId": "delete_connection",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "connection_ids": {
+                    "default": [],
+                    "description": "连接ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Connection Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": {},
+                    "description": "蜜罐事件类型字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Event Types",
+                    "type": "object"
+                  },
+                  "honeypot_ids": {
+                    "default": [],
+                    "description": "蜜罐ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "connection ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "portrait_id": {
+                    "default": [],
+                    "description": "溯源numID列表，为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Portrait Id",
+                    "type": "array"
+                  },
+                  "proto": {
+                    "description": "连接协议，如'tcp'、'udp'",
+                    "title": "Proto",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  },
+                  "webshell_id": {
+                    "description": "Webshell的ID，为空时不对此项做过滤",
+                    "title": "Webshell Id",
+                    "type": "string"
+                  }
+                },
+                "title": "ConnectionFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "删除蜜罐入侵日志",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "DeleteConnectionRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除蜜罐入侵日志",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/type/list": {
+      "post": {
+        "operationId": "list_type",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": [],
+                      "description": "事件类型列表",
+                      "items": {},
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "EventTypeListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取蜜罐入侵事件类型",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/download": {
+      "post": {
+        "operationId": "download_event_files",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "default": [],
+                    "description": "文件 ID 列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "default": "",
+                    "description": "节点node",
+                    "title": "Node",
+                    "type": "string"
+                  }
+                },
+                "title": "DownloadEventFilesArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "文件下载路径",
+                      "title": "Data",
+                      "type": "object"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "DownloadEventFilesRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "全部遗留文件下载",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/log/download_token": {
+      "post": {
+        "operationId": "generate_event_download_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "connection_ids": {
+                    "default": [],
+                    "description": "连接ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Connection Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": {},
+                    "description": "蜜罐事件类型字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Event Types",
+                    "type": "object"
+                  },
+                  "honeypot_ids": {
+                    "default": [],
+                    "description": "蜜罐ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "connection ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "portrait_id": {
+                    "default": [],
+                    "description": "溯源numID列表，为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Portrait Id",
+                    "type": "array"
+                  },
+                  "proto": {
+                    "description": "连接协议，如'tcp'、'udp'",
+                    "title": "Proto",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  },
+                  "webshell_id": {
+                    "description": "Webshell的ID，为空时不对此项做过滤",
+                    "title": "Webshell Id",
+                    "type": "string"
+                  }
+                },
+                "title": "ConnectionFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetEventId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetEventIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成json格式蜜罐入侵日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/log/download_csv_token": {
+      "post": {
+        "operationId": "generate_event_download_csv_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "connection_ids": {
+                    "default": [],
+                    "description": "连接ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Connection Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": {},
+                    "description": "蜜罐事件类型字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Event Types",
+                    "type": "object"
+                  },
+                  "honeypot_ids": {
+                    "default": [],
+                    "description": "蜜罐ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "connection ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "portrait_id": {
+                    "default": [],
+                    "description": "溯源numID列表，为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Portrait Id",
+                    "type": "array"
+                  },
+                  "proto": {
+                    "description": "连接协议，如'tcp'、'udp'",
+                    "title": "Proto",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  },
+                  "webshell_id": {
+                    "description": "Webshell的ID，为空时不对此项做过滤",
+                    "title": "Webshell Id",
+                    "type": "string"
+                  }
+                },
+                "title": "ConnectionFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetEventId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetEventIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成csv格式蜜罐入侵日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/log/json/download/start": {
+      "post": {
+        "operationId": "start_bg_download_event_logs_json_new",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "connection_ids": {
+                    "default": [],
+                    "description": "连接ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Connection Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": {},
+                    "description": "蜜罐事件类型字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Event Types",
+                    "type": "object"
+                  },
+                  "honeypot_ids": {
+                    "default": [],
+                    "description": "蜜罐ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "connection ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "portrait_id": {
+                    "default": [],
+                    "description": "溯源numID列表，为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Portrait Id",
+                    "type": "array"
+                  },
+                  "proto": {
+                    "description": "连接协议，如'tcp'、'udp'",
+                    "title": "Proto",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  },
+                  "webshell_id": {
+                    "description": "Webshell的ID，为空时不对此项做过滤",
+                    "title": "Webshell Id",
+                    "type": "string"
+                  }
+                },
+                "title": "ConnectionFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetEventId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetEventIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "后台下载入侵日志json",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/log/download_excel_token": {
+      "post": {
+        "operationId": "generate_event_download_excel_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "connection_ids": {
+                    "default": [],
+                    "description": "连接ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Connection Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": {},
+                    "description": "蜜罐事件类型字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Event Types",
+                    "type": "object"
+                  },
+                  "honeypot_ids": {
+                    "default": [],
+                    "description": "蜜罐ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "connection ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "portrait_id": {
+                    "default": [],
+                    "description": "溯源numID列表，为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Portrait Id",
+                    "type": "array"
+                  },
+                  "proto": {
+                    "description": "连接协议，如'tcp'、'udp'",
+                    "title": "Proto",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  },
+                  "webshell_id": {
+                    "description": "Webshell的ID，为空时不对此项做过滤",
+                    "title": "Webshell Id",
+                    "type": "string"
+                  }
+                },
+                "title": "ConnectionFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetEventId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetEventIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成excel格式蜜罐入侵日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/pwd/download_token": {
+      "post": {
+        "operationId": "generate_pwd_download_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "connection_ids": {
+                    "default": [],
+                    "description": "连接ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Connection Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": {},
+                    "description": "蜜罐事件类型字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Event Types",
+                    "type": "object"
+                  },
+                  "honeypot_ids": {
+                    "default": [],
+                    "description": "蜜罐ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "connection ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "portrait_id": {
+                    "default": [],
+                    "description": "溯源numID列表，为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Portrait Id",
+                    "type": "array"
+                  },
+                  "proto": {
+                    "description": "连接协议，如'tcp'、'udp'",
+                    "title": "Proto",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  },
+                  "webshell_id": {
+                    "description": "Webshell的ID，为空时不对此项做过滤",
+                    "title": "Webshell Id",
+                    "type": "string"
+                  }
+                },
+                "title": "ConnectionFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetEventId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetEventIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成json格式弱口令聚合日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/pwd/download_csv_token": {
+      "post": {
+        "operationId": "generate_pwd_download_csv_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "connection_ids": {
+                    "default": [],
+                    "description": "连接ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Connection Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": {},
+                    "description": "蜜罐事件类型字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Event Types",
+                    "type": "object"
+                  },
+                  "honeypot_ids": {
+                    "default": [],
+                    "description": "蜜罐ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "connection ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "portrait_id": {
+                    "default": [],
+                    "description": "溯源numID列表，为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Portrait Id",
+                    "type": "array"
+                  },
+                  "proto": {
+                    "description": "连接协议，如'tcp'、'udp'",
+                    "title": "Proto",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  },
+                  "webshell_id": {
+                    "description": "Webshell的ID，为空时不对此项做过滤",
+                    "title": "Webshell Id",
+                    "type": "string"
+                  }
+                },
+                "title": "ConnectionFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetEventId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetEventIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成csv格式蜜罐入侵日志弱口令聚合下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/pwd/download_excel_token": {
+      "post": {
+        "operationId": "generate_pwd_download_excel_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": {},
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "title": "Agent Ids",
+                    "type": "object"
+                  },
+                  "business_groups": {
+                    "default": {},
+                    "description": "业务组列表",
+                    "title": "Business Groups",
+                    "type": "object"
+                  },
+                  "connection_ids": {
+                    "default": [],
+                    "description": "连接ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Connection Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": {},
+                    "description": "蜜罐事件类型字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Event Types",
+                    "type": "object"
+                  },
+                  "honeypot_ids": {
+                    "default": [],
+                    "description": "蜜罐ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypot Ids",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "connection ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "portrait_id": {
+                    "default": [],
+                    "description": "溯源numID列表，为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Portrait Id",
+                    "type": "array"
+                  },
+                  "proto": {
+                    "description": "连接协议，如'tcp'、'udp'",
+                    "title": "Proto",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "发起连接IP所在城市，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "发起连接IP所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "tenants": {
+                    "default": [],
+                    "description": "租户列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tenants",
+                    "type": "array"
+                  },
+                  "webshell_id": {
+                    "description": "Webshell的ID，为空时不对此项做过滤",
+                    "title": "Webshell Id",
+                    "type": "string"
+                  }
+                },
+                "title": "ConnectionFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetEventId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetEventIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成excel格式蜜罐入侵日志弱口令下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/v1/list_portrait": {
+      "post": {
+        "operationId": "list_portrait",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "contain_social_info": {
+                    "default": [],
+                    "description": "是否包含社交信息，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "boolean"
+                    },
+                    "title": "Contain Social Info",
+                    "type": "array"
+                  },
+                  "external_ips": {
+                    "default": [],
+                    "description": "攻击者代理IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "External Ips",
+                    "type": "array"
+                  },
+                  "honeypots": {
+                    "default": [],
+                    "description": "蜜罐列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypots",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "numids": {
+                    "default": [],
+                    "description": "溯源事件ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Numids",
+                    "type": "array"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "real_ips": {
+                    "default": [],
+                    "description": "攻击者真实的外网IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Real Ips",
+                    "type": "array"
+                  },
+                  "regex": {
+                    "default": false,
+                    "title": "Regex",
+                    "type": "boolean"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "攻击者所在城市列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "攻击者所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": [],
+                    "description": "攻击者直接攻击IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Ips",
+                    "type": "array"
+                  },
+                  "tagids": {
+                    "default": [],
+                    "description": "溯源事件数字ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tagids",
+                    "type": "array"
+                  }
+                },
+                "title": "ListPortraitV1Arg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "ListPortraitV1Ret",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "攻击者画像列表",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/delete_portrait": {
+      "post": {
+        "operationId": "delete_portrait",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于溯源事件的统一筛选参数",
+                "properties": {
+                  "contain_social_info": {
+                    "default": [],
+                    "description": "是否包含社交信息，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "boolean"
+                    },
+                    "title": "Contain Social Info",
+                    "type": "array"
+                  },
+                  "external_ips": {
+                    "default": [],
+                    "description": "攻击者代理IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "External Ips",
+                    "type": "array"
+                  },
+                  "honeypots": {
+                    "default": [],
+                    "description": "蜜罐列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypots",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "numids": {
+                    "default": [],
+                    "description": "溯源事件ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Numids",
+                    "type": "array"
+                  },
+                  "real_ips": {
+                    "default": [],
+                    "description": "攻击者真实的外网IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Real Ips",
+                    "type": "array"
+                  },
+                  "regex": {
+                    "default": false,
+                    "title": "Regex",
+                    "type": "boolean"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "攻击者所在城市列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "攻击者所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": [],
+                    "description": "攻击者直接攻击IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Ips",
+                    "type": "array"
+                  },
+                  "tagids": {
+                    "default": [],
+                    "description": "溯源事件数字ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tagids",
+                    "type": "array"
+                  }
+                },
+                "title": "PortraitFilterV1",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "删除溯源日志",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DeletePortraitRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除溯源日志",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/portrait/download_token": {
+      "post": {
+        "operationId": "generate_portrait_download_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于溯源事件的统一筛选参数",
+                "properties": {
+                  "contain_social_info": {
+                    "default": [],
+                    "description": "是否包含社交信息，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "boolean"
+                    },
+                    "title": "Contain Social Info",
+                    "type": "array"
+                  },
+                  "external_ips": {
+                    "default": [],
+                    "description": "攻击者代理IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "External Ips",
+                    "type": "array"
+                  },
+                  "honeypots": {
+                    "default": [],
+                    "description": "蜜罐列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypots",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "numids": {
+                    "default": [],
+                    "description": "溯源事件ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Numids",
+                    "type": "array"
+                  },
+                  "real_ips": {
+                    "default": [],
+                    "description": "攻击者真实的外网IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Real Ips",
+                    "type": "array"
+                  },
+                  "regex": {
+                    "default": false,
+                    "title": "Regex",
+                    "type": "boolean"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "攻击者所在城市列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "攻击者所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": [],
+                    "description": "攻击者直接攻击IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Ips",
+                    "type": "array"
+                  },
+                  "tagids": {
+                    "default": [],
+                    "description": "溯源事件数字ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tagids",
+                    "type": "array"
+                  }
+                },
+                "title": "PortraitFilterV1",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetPortraitId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetPortraitIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成json格式溯源日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/portrait/download_csv_token": {
+      "post": {
+        "operationId": "generate_portrait_download_csv_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于溯源事件的统一筛选参数",
+                "properties": {
+                  "contain_social_info": {
+                    "default": [],
+                    "description": "是否包含社交信息，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "boolean"
+                    },
+                    "title": "Contain Social Info",
+                    "type": "array"
+                  },
+                  "external_ips": {
+                    "default": [],
+                    "description": "攻击者代理IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "External Ips",
+                    "type": "array"
+                  },
+                  "honeypots": {
+                    "default": [],
+                    "description": "蜜罐列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypots",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "numids": {
+                    "default": [],
+                    "description": "溯源事件ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Numids",
+                    "type": "array"
+                  },
+                  "real_ips": {
+                    "default": [],
+                    "description": "攻击者真实的外网IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Real Ips",
+                    "type": "array"
+                  },
+                  "regex": {
+                    "default": false,
+                    "title": "Regex",
+                    "type": "boolean"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "攻击者所在城市列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "攻击者所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": [],
+                    "description": "攻击者直接攻击IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Ips",
+                    "type": "array"
+                  },
+                  "tagids": {
+                    "default": [],
+                    "description": "溯源事件数字ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tagids",
+                    "type": "array"
+                  }
+                },
+                "title": "PortraitFilterV1",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetPortraitId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetPortraitIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成csv格式溯源日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/portrait/download_excel_token": {
+      "post": {
+        "operationId": "generate_portrait_download_excel_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于溯源事件的统一筛选参数",
+                "properties": {
+                  "contain_social_info": {
+                    "default": [],
+                    "description": "是否包含社交信息，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "boolean"
+                    },
+                    "title": "Contain Social Info",
+                    "type": "array"
+                  },
+                  "external_ips": {
+                    "default": [],
+                    "description": "攻击者代理IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "External Ips",
+                    "type": "array"
+                  },
+                  "honeypots": {
+                    "default": [],
+                    "description": "蜜罐列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Honeypots",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "numids": {
+                    "default": [],
+                    "description": "溯源事件ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Numids",
+                    "type": "array"
+                  },
+                  "real_ips": {
+                    "default": [],
+                    "description": "攻击者真实的外网IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Real Ips",
+                    "type": "array"
+                  },
+                  "regex": {
+                    "default": false,
+                    "title": "Regex",
+                    "type": "boolean"
+                  },
+                  "src_cities": {
+                    "default": [],
+                    "description": "攻击者所在城市列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Cities",
+                    "type": "array"
+                  },
+                  "src_countries": {
+                    "default": [],
+                    "description": "攻击者所在国家列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Countries",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": [],
+                    "description": "攻击者直接攻击IP列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Ips",
+                    "type": "array"
+                  },
+                  "tagids": {
+                    "default": [],
+                    "description": "溯源事件数字ID列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Tagids",
+                    "type": "array"
+                  }
+                },
+                "title": "PortraitFilterV1",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetPortraitId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetPortraitIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成excel格式溯源日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/portrait/filter_params": {
+      "post": {
+        "operationId": "download_portrait_event_excel",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetPortraitParamData"
+                        }
+                      ],
+                      "description": "参数数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetPortraitParamRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取溯源筛选数据",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/ping/delete": {
+      "post": {
+        "operationId": "delete_ping",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "要删除的ping扫描日志的id列表",
+                    "items": {},
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "DeletePingEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "删除ping扫描日志",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DeletePingEventRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除ping扫描日志",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/ping/delete_all": {
+      "post": {
+        "operationId": "delete_all_ping",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "agent_id": {
+                    "default": {},
+                    "description": "探针sn列表，列表为空时不对此项做过滤",
+                    "title": "Agent Id",
+                    "type": "object"
+                  },
+                  "dest_ip": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ip",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "ping ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "src_ip": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ip",
+                    "type": "object"
+                  }
+                },
+                "title": "ListPingEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "Ping日志删除筛选",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/ping/list": {
+      "post": {
+        "operationId": "filter_ping_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "agent_id": {
+                    "default": {},
+                    "description": "探针sn列表，列表为空时不对此项做过滤",
+                    "title": "Agent Id",
+                    "type": "object"
+                  },
+                  "dest_ip": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ip",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "ping ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "src_ip": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ip",
+                    "type": "object"
+                  }
+                },
+                "title": "ListPingEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "ListPingEventRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "Ping扫描日志列表",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/ping/download_token": {
+      "post": {
+        "operationId": "generate_ping_download_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于Ping事件的统一筛选参数\n\n警告: dest_port_ranges字段不为空列表时，会发生一次成本可能不可忽略的数据库查询",
+                "properties": {
+                  "agent_id": {
+                    "default": {},
+                    "description": "探针sn列表，列表为空时不对此项做过滤",
+                    "title": "Agent Id",
+                    "type": "object"
+                  },
+                  "dest_ip": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ip",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "ping ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "src_ip": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ip",
+                    "type": "object"
+                  }
+                },
+                "title": "PingEventFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetPingId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetPingIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成json格式端口探测日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/ping/download_csv_token": {
+      "post": {
+        "operationId": "ping_event_download_csv_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于Ping事件的统一筛选参数\n\n警告: dest_port_ranges字段不为空列表时，会发生一次成本可能不可忽略的数据库查询",
+                "properties": {
+                  "agent_id": {
+                    "default": {},
+                    "description": "探针sn列表，列表为空时不对此项做过滤",
+                    "title": "Agent Id",
+                    "type": "object"
+                  },
+                  "dest_ip": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ip",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "ping ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "src_ip": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ip",
+                    "type": "object"
+                  }
+                },
+                "title": "PingEventFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetPingId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetPingIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成csv格式蜜罐入侵日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/ping/download_excel_token": {
+      "post": {
+        "operationId": "ping_event_download_excel_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "用于Ping事件的统一筛选参数\n\n警告: dest_port_ranges字段不为空列表时，会发生一次成本可能不可忽略的数据库查询",
+                "properties": {
+                  "agent_id": {
+                    "default": {},
+                    "description": "探针sn列表，列表为空时不对此项做过滤",
+                    "title": "Agent Id",
+                    "type": "object"
+                  },
+                  "dest_ip": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ip",
+                    "type": "object"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "ping ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "src_ip": {
+                    "default": {},
+                    "description": "源IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ip",
+                    "type": "object"
+                  }
+                },
+                "title": "PingEventFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetPingId"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetPingIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成excel格式端口探测日志下载凭证",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/arp/list": {
+      "post": {
+        "operationId": "list_arp_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "agent_id": {
+                    "default": {},
+                    "description": "探针sn列表，列表为空时不对此项做过滤",
+                    "title": "Agent Id",
+                    "type": "object"
+                  },
+                  "dest_ip": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ip",
+                    "type": "object"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "src_ip": {
+                    "default": {},
+                    "description": "伪装IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ip",
+                    "type": "object"
+                  }
+                },
+                "title": "ListArpEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "ListArpEventRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "ARP欺骗日志列表",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/arp/delete": {
+      "post": {
+        "operationId": "delete_arp_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "待删除的ARP事件记录的ID",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "DeleteArpEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "删除ARP扫描日志",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DeleteArpEventRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除ARP扫描日志",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/arp/delete_all": {
+      "post": {
+        "operationId": "delete_all_arp_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "agent_id": {
+                    "default": {},
+                    "description": "探针sn列表，列表为空时不对此项做过滤",
+                    "title": "Agent Id",
+                    "type": "object"
+                  },
+                  "dest_ip": {
+                    "default": {},
+                    "description": "目标IP列表，列表为空时不对此项做过滤",
+                    "title": "Dest Ip",
+                    "type": "object"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "src_ip": {
+                    "default": {},
+                    "description": "伪装IP列表，列表为空时不对此项做过滤",
+                    "title": "Src Ip",
+                    "type": "object"
+                  }
+                },
+                "title": "ListArpEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除全部ARP欺骗日志",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/attack_source/list": {
+      "post": {
+        "operationId": "list_attack_source",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做过滤",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "order_by": {
+                    "default": [],
+                    "description": "支持排序功能，目前仅支持AttackSourceOrderTypeEnum以下类型",
+                    "items": {
+                      "$ref": "#/components/schemas/OrderByInfo"
+                    },
+                    "title": "Order By",
+                    "type": "array"
+                  },
+                  "risk_levels": {
+                    "default": [],
+                    "description": "风险等级，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        1,
+                        2,
+                        3,
+                        4
+                      ],
+                      "type": "integer"
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": [],
+                    "description": "攻击源IP，列表为空时不对此项做筛选",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Src Ips",
+                    "type": "array"
+                  },
+                  "top_n_agent": {
+                    "default": 5,
+                    "description": "响应入侵日志最多的N个探针",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "Top N Agent",
+                    "type": "integer"
+                  }
+                },
+                "title": "ListAttackSourceArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AttackSourceRet"
+                        }
+                      ],
+                      "default": [],
+                      "description": "攻击源分析数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ListAttackSourceRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "攻击源分析数据",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/attack_source/detail": {
+      "post": {
+        "operationId": "attack_source_detail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "node": {
+                    "description": "节点ID",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "order_by": {
+                    "default": [],
+                    "description": "支持排序功能，目前仅支持AttackSourceOrderTypeEnum以下类型",
+                    "items": {
+                      "$ref": "#/components/schemas/OrderByInfo"
+                    },
+                    "title": "Order By",
+                    "type": "array"
+                  },
+                  "risk_levels": {
+                    "default": [],
+                    "description": "风险等级，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        1,
+                        2,
+                        3,
+                        4
+                      ],
+                      "type": "integer"
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_ip": {
+                    "description": "需要查询的IP地址",
+                    "format": "ipvanyaddress",
+                    "title": "Src Ip",
+                    "type": "string"
+                  },
+                  "top_n_agent": {
+                    "default": 5,
+                    "description": "响应入侵日志最多的N个探针",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "Top N Agent",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "src_ip"
+                ],
+                "title": "AttackSourceDetailArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AttackSourceDetail"
+                        }
+                      ],
+                      "description": "攻击源分析详细事件",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AttackSourceDetailRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "攻击源分析详细事件",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/attack_source/event_timeline": {
+      "post": {
+        "operationId": "event_timeline",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "开始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "default": [],
+                    "description": "风险等级，列表为空时不对此项做筛选",
+                    "items": {
+                      "enum": [
+                        1,
+                        2,
+                        3,
+                        4
+                      ],
+                      "type": "integer"
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_ip": {
+                    "description": "源ip地址",
+                    "title": "Src Ip",
+                    "type": "string"
+                  },
+                  "unit": {
+                    "description": "unit",
+                    "title": "Unit",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "unit",
+                  "not_before",
+                  "not_after",
+                  "src_ip"
+                ],
+                "title": "GetEventTimelineArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "事件数组，统计出每天的事件数量",
+                      "items": {
+                        "$ref": "#/components/schemas/EventTimeLine"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "RetGetEventTimeline",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "统计出每天的事件数量",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/event_alarm/count": {
+      "post": {
+        "operationId": "get_alarm_count",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "GetAlarmCountArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "未处置事件的数量",
+                      "title": "Data",
+                      "type": "object"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "RetGetAlarmCount",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取没有处理的告警数量",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/event_alarm/list": {
+      "post": {
+        "operationId": "list_alarm_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": [],
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Agent Ids",
+                    "type": "array"
+                  },
+                  "alarm_ids": {
+                    "default": [],
+                    "description": "告警事件id",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Ids",
+                    "type": "array"
+                  },
+                  "business_groups": {
+                    "default": [],
+                    "description": "业务组列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Business Groups",
+                    "type": "array"
+                  },
+                  "dest_ips": {
+                    "default": {},
+                    "description": "目标IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Dest Ips",
+                    "type": "object"
+                  },
+                  "handle_status": {
+                    "default": [],
+                    "description": "事件处置状态",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Handle Status",
+                    "type": "array"
+                  },
+                  "id_order": {
+                    "description": "id排序方式",
+                    "title": "Id Order",
+                    "type": "string"
+                  },
+                  "last_alarm_time_order": {
+                    "description": "最后告警时间排序方式",
+                    "title": "Last Alarm Time Order",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "risk_level_order": {
+                    "description": "风险级别排序方式",
+                    "title": "Risk Level Order",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "default": [],
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "事件状态列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Status",
+                    "type": "array"
+                  },
+                  "status_order": {
+                    "description": "处置状态排序方式",
+                    "title": "Status Order",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "status",
+                  "id_order",
+                  "last_alarm_time_order",
+                  "risk_level_order",
+                  "status_order"
+                ],
+                "title": "ListAlarmEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ListAlarmEvent"
+                        }
+                      ],
+                      "description": "excel meta信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "FilterAlarmEventRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "告警中心列表",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/event_alarm/bulk_handle": {
+      "post": {
+        "operationId": "bulk_handle_alarm_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": [],
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Agent Ids",
+                    "type": "array"
+                  },
+                  "alarm_ids": {
+                    "default": [],
+                    "description": "告警事件id",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Ids",
+                    "type": "array"
+                  },
+                  "business_groups": {
+                    "default": [],
+                    "description": "业务组列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Business Groups",
+                    "type": "array"
+                  },
+                  "description": {
+                    "description": "事件处置的的概述",
+                    "title": "Description",
+                    "type": "string"
+                  },
+                  "dest_ips": {
+                    "default": {},
+                    "description": "目标IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Dest Ips",
+                    "type": "object"
+                  },
+                  "handle_status": {
+                    "default": [],
+                    "description": "事件处置状态",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Handle Status",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "default": [],
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "set_status": {
+                    "description": "批量处置的状态",
+                    "enum": [
+                      1,
+                      2,
+                      3
+                    ],
+                    "title": "Set Status",
+                    "type": "integer"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "事件状态列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Status",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "status",
+                  "set_status",
+                  "description"
+                ],
+                "title": "BatchHandleAlarmEventArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "告警中心批量处置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "BatchHandleAlarmEventRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "告警中心批量处置",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/event_alarm/delete": {
+      "post": {
+        "operationId": "delete_alarm_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "agent_ids": {
+                    "default": [],
+                    "description": "探针ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Agent Ids",
+                    "type": "array"
+                  },
+                  "alarm_ids": {
+                    "default": [],
+                    "description": "告警事件id",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Alarm Ids",
+                    "type": "array"
+                  },
+                  "business_groups": {
+                    "default": [],
+                    "description": "业务组列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Business Groups",
+                    "type": "array"
+                  },
+                  "dest_ips": {
+                    "default": {},
+                    "description": "目标IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Dest Ips",
+                    "type": "object"
+                  },
+                  "handle_status": {
+                    "default": [],
+                    "description": "事件处置状态",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Handle Status",
+                    "type": "array"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "risk_levels": {
+                    "default": [],
+                    "description": "威胁等级列表，列表为空时不对此项做筛选",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "integer"
+                        }
+                      ]
+                    },
+                    "title": "Risk Levels",
+                    "type": "array"
+                  },
+                  "src_ips": {
+                    "default": {},
+                    "description": "来源IP字典，字典为空时不对此项做筛选，eq表示属于，ne表示不属于",
+                    "title": "Src Ips",
+                    "type": "object"
+                  },
+                  "status": {
+                    "description": "事件状态列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Status",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "status"
+                ],
+                "title": "DeleteAlarmEventArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "告警中心批量删除",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DeleteAlarmEventRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "告警中心批量删除",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/log_excel_meta/get": {
+      "post": {
+        "operationId": "get_log_excel_meta",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "log_type": {
+                    "description": "事情类型",
+                    "enum": [
+                      "conneciton",
+                      "scanner",
+                      "portrait",
+                      "ping",
+                      "weakpwd"
+                    ],
+                    "title": "Log Type",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "log_type"
+                ],
+                "title": "DownloadExcelMetaArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "excel meta信息",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "DownloadExcelMetaRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "根据事件类型获取excel表头信息",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/event_type/list": {
+      "post": {
+        "operationId": "list_event_type",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": {},
+                      "description": "事件类型列表",
+                      "title": "Data",
+                      "type": "object"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ListEventTypeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "入侵事件的风险等级",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/bait/list": {
+      "post": {
+        "operationId": "list_bait_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "assess_key_ids": {
+                    "default": [],
+                    "description": "key id列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Assess Key Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": [],
+                    "description": "事件类型",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Event Types",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "诱饵事件id列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "remarks": {
+                    "default": [],
+                    "description": "备注列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Remarks",
+                    "type": "array"
+                  },
+                  "source_ips": {
+                    "default": {},
+                    "description": "源ip列表，eq表示属于，ne表示不属于",
+                    "title": "Source Ips",
+                    "type": "object"
+                  }
+                },
+                "title": "ListBaitEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "description": "实际返回的数据",
+                      "items": {
+                        "$ref": "#/components/schemas/BaitEventItem"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "total": {
+                      "description": "满足条件的记录总数",
+                      "minimum": 0,
+                      "title": "Total",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "data"
+                  ],
+                  "title": "BaitEventListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "诱饵事件列表",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/bait/delete": {
+      "post": {
+        "operationId": "delete_bait_event",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "待删除的诱饵事件记录的ID",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "DeleteBaitEventArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除诱饵事件",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/bait/delete_all": {
+      "post": {
+        "operationId": "delete_all_bait_event",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除所有诱饵事件",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/bait/detail": {
+      "post": {
+        "operationId": "bait_event_detail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "诱饵事件id",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "BaitEventDetailArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/BaitEventItem"
+                        }
+                      ],
+                      "description": "诱饵事件详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "BaitEventDetailRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "诱饵事件详情",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/bait/download_token": {
+      "post": {
+        "operationId": "generate_bait_download_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "assess_key_ids": {
+                    "default": [],
+                    "description": "key id列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Assess Key Ids",
+                    "type": "array"
+                  },
+                  "event_types": {
+                    "default": [],
+                    "description": "事件类型",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Event Types",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "诱饵事件id列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "remarks": {
+                    "default": [],
+                    "description": "备注列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Remarks",
+                    "type": "array"
+                  },
+                  "source_ips": {
+                    "default": {},
+                    "description": "源ip列表，eq表示属于，ne表示不属于",
+                    "title": "Source Ips",
+                    "type": "object"
+                  }
+                },
+                "title": "GenerateBaitDownloadTokenArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetBaitDownloadToken"
+                        }
+                      ],
+                      "description": "下载凭证",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GenerateBaitDownloadTokenRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成诱饵事件下载token",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/event/bait/event_type/list": {
+      "post": {
+        "operationId": "list_bait_event_type",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "诱饵事件类型列表",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "ListBaitEventTypeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "诱饵事件类型列表",
+        "tags": [
+          "攻击者画像与威胁日志"
+        ]
+      }
+    },
+    "/api/log/syslog/list": {
+      "post": {
+        "operationId": "syslog_config_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  }
+                },
+                "title": "SyslogConfigListArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "description": "实际返回的数据",
+                      "items": {
+                        "$ref": "#/components/schemas/SyslogConfigDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "total": {
+                      "description": "满足条件的记录总数",
+                      "minimum": 0,
+                      "title": "Total",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "data"
+                  ],
+                  "title": "SyslogConfigListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "syslog配置列表",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/log/syslog/delete": {
+      "post": {
+        "operationId": "delete_syslog_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "待删除的配置信息ID",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "DeleteSyslogConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除syslog配置信息",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/log/syslog/add": {
+      "post": {
+        "operationId": "add_syslog_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_status": {
+                    "description": "是否报告探针连接状态变化",
+                    "title": "Agent Status",
+                    "type": "boolean"
+                  },
+                  "arp_event": {
+                    "description": "是否报告ARP攻击",
+                    "title": "Arp Event",
+                    "type": "boolean"
+                  },
+                  "docker_escape": {
+                    "description": "是否报告docker逃逸事件",
+                    "title": "Docker Escape",
+                    "type": "boolean"
+                  },
+                  "encoding": {
+                    "description": "syslog编码方式",
+                    "enum": [
+                      "Unicode",
+                      "UTF-8"
+                    ],
+                    "title": "Encoding"
+                  },
+                  "format": {
+                    "default": "rfc5424",
+                    "description": "syslog格式",
+                    "enum": [
+                      "rfc3164",
+                      "rfc5424"
+                    ],
+                    "title": "Format"
+                  },
+                  "honeypot_event": {
+                    "description": "是否报告蜜罐事件",
+                    "title": "Honeypot Event",
+                    "type": "boolean"
+                  },
+                  "host": {
+                    "description": "syslog服务器地址",
+                    "minLength": 1,
+                    "title": "Host",
+                    "type": "string"
+                  },
+                  "is_base64_decode": {
+                    "default": false,
+                    "description": "是否base64解码日志中的header",
+                    "title": "Is Base64 Decode",
+                    "type": "boolean"
+                  },
+                  "ping_event": {
+                    "description": "是否报告ping事件",
+                    "title": "Ping Event",
+                    "type": "boolean"
+                  },
+                  "port": {
+                    "description": "syslog服务器端口",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "title": "Port",
+                    "type": "integer"
+                  },
+                  "portrait_event": {
+                    "description": "是否报告溯源事件",
+                    "title": "Portrait Event",
+                    "type": "boolean"
+                  },
+                  "scanner_event": {
+                    "description": "是否报告扫描事件",
+                    "title": "Scanner Event",
+                    "type": "boolean"
+                  },
+                  "socket_type": {
+                    "description": "syslog的网络传输方式",
+                    "enum": [
+                      "TCP",
+                      "UDP"
+                    ],
+                    "title": "Socket Type"
+                  },
+                  "time_diff": {
+                    "default": 0,
+                    "description": "自定义加减整数时间差",
+                    "title": "Time Diff",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "host",
+                  "port",
+                  "encoding",
+                  "honeypot_event",
+                  "scanner_event",
+                  "ping_event",
+                  "portrait_event",
+                  "arp_event",
+                  "docker_escape",
+                  "agent_status",
+                  "socket_type"
+                ],
+                "title": "AddSyslogConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "新创建的配置信息的ID",
+                      "title": "Id",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "title": "AddSyslogConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "添加syslog配置信息",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/log/syslog/modify": {
+      "post": {
+        "operationId": "modify_syslog_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_status": {
+                    "description": "是否报告探针连接状态变化",
+                    "title": "Agent Status",
+                    "type": "boolean"
+                  },
+                  "arp_event": {
+                    "description": "是否报告ARP攻击",
+                    "title": "Arp Event",
+                    "type": "boolean"
+                  },
+                  "docker_escape": {
+                    "description": "是否报告docker逃逸事件",
+                    "title": "Docker Escape",
+                    "type": "boolean"
+                  },
+                  "encoding": {
+                    "description": "syslog编码方式",
+                    "enum": [
+                      "Unicode",
+                      "UTF-8"
+                    ],
+                    "title": "Encoding"
+                  },
+                  "format": {
+                    "default": "rfc5424",
+                    "description": "syslog格式",
+                    "enum": [
+                      "rfc3164",
+                      "rfc5424"
+                    ],
+                    "title": "Format"
+                  },
+                  "honeypot_event": {
+                    "description": "是否报告蜜罐事件",
+                    "title": "Honeypot Event",
+                    "type": "boolean"
+                  },
+                  "host": {
+                    "description": "syslog服务器地址",
+                    "minLength": 1,
+                    "title": "Host",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "syslog配置的ID",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "is_base64_decode": {
+                    "default": false,
+                    "description": "是否base64解码日志中的header",
+                    "title": "Is Base64 Decode",
+                    "type": "boolean"
+                  },
+                  "ping_event": {
+                    "description": "是否报告ping事件",
+                    "title": "Ping Event",
+                    "type": "boolean"
+                  },
+                  "port": {
+                    "description": "syslog服务器端口",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "title": "Port",
+                    "type": "integer"
+                  },
+                  "portrait_event": {
+                    "description": "是否报告溯源事件",
+                    "title": "Portrait Event",
+                    "type": "boolean"
+                  },
+                  "scanner_event": {
+                    "description": "是否报告扫描事件",
+                    "title": "Scanner Event",
+                    "type": "boolean"
+                  },
+                  "socket_type": {
+                    "description": "syslog的网络传输方式",
+                    "enum": [
+                      "TCP",
+                      "UDP"
+                    ],
+                    "title": "Socket Type"
+                  },
+                  "time_diff": {
+                    "default": 0,
+                    "description": "自定义加减整数时间差",
+                    "title": "Time Diff",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "id",
+                  "host",
+                  "port",
+                  "encoding",
+                  "socket_type",
+                  "honeypot_event",
+                  "scanner_event",
+                  "portrait_event",
+                  "ping_event",
+                  "arp_event",
+                  "docker_escape",
+                  "agent_status"
+                ],
+                "title": "SyslogConfigDetail",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改syslog配置信息",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/log/kafka/list": {
+      "post": {
+        "operationId": "kafka_config_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  }
+                },
+                "title": "KafkaConfigListArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "description": "实际返回的数据",
+                      "items": {
+                        "$ref": "#/components/schemas/KafkaConfigDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "total": {
+                      "description": "满足条件的记录总数",
+                      "minimum": 0,
+                      "title": "Total",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "data"
+                  ],
+                  "title": "KafkaConfigListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "kafka配置列表",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/log/kafka/delete": {
+      "post": {
+        "operationId": "delete_kafka_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "待删除的配置信息ID",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "DeleteKafkaConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除kafka配置信息",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/log/kafka/add": {
+      "post": {
+        "operationId": "add_kafka_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ack_type": {
+                    "description": "kafka的响应方式",
+                    "enum": [
+                      "none",
+                      "wait_leader",
+                      "wait_all"
+                    ],
+                    "title": "Ack Type",
+                    "type": "string"
+                  },
+                  "config": {
+                    "description": "kafka的响应方式，honeypot表示是否报告蜜罐事件, scanner:是否报告扫描事件, portrait表示是否报告溯源事件,ping表示是否报告ping事件, arp表示是否报告ARP攻击, docker_escape表示是否报告docker逃逸事件,agent_status表示是否报告探针连接状态变化",
+                    "items": {
+                      "enum": [
+                        "honeypot",
+                        "scanner",
+                        "portrait",
+                        "ping",
+                        "arp",
+                        "docker_escape",
+                        "agent_status"
+                      ],
+                      "type": "string"
+                    },
+                    "title": "Config",
+                    "type": "array"
+                  },
+                  "encoding": {
+                    "description": "kafka编码方式",
+                    "enum": [
+                      "GBK",
+                      "UTF-8"
+                    ],
+                    "title": "Encoding",
+                    "type": "string"
+                  },
+                  "host": {
+                    "description": "kafka服务器地址",
+                    "minLength": 1,
+                    "title": "Host",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "配置的ID",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "password": {
+                    "default": "",
+                    "description": "密码",
+                    "title": "Password",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "kafka服务器端口",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "title": "Port",
+                    "type": "integer"
+                  },
+                  "topic_name": {
+                    "description": "topic名称",
+                    "minLength": 1,
+                    "title": "Topic Name",
+                    "type": "string"
+                  },
+                  "username": {
+                    "default": "",
+                    "description": "用户名",
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "topic_name",
+                  "host",
+                  "port",
+                  "encoding",
+                  "ack_type",
+                  "config"
+                ],
+                "title": "KafkaConfigDetail",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "新创建的配置信息的ID",
+                      "title": "Id",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "title": "AddKafkaConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "添加kafka配置信息",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/log/kafka/modify": {
+      "post": {
+        "operationId": "modify_kafka_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ack_type": {
+                    "description": "kafka的响应方式",
+                    "enum": [
+                      "none",
+                      "wait_leader",
+                      "wait_all"
+                    ],
+                    "title": "Ack Type",
+                    "type": "string"
+                  },
+                  "config": {
+                    "description": "kafka的响应方式，honeypot表示是否报告蜜罐事件, scanner:是否报告扫描事件, portrait表示是否报告溯源事件,ping表示是否报告ping事件, arp表示是否报告ARP攻击, docker_escape表示是否报告docker逃逸事件,agent_status表示是否报告探针连接状态变化",
+                    "items": {
+                      "enum": [
+                        "honeypot",
+                        "scanner",
+                        "portrait",
+                        "ping",
+                        "arp",
+                        "docker_escape",
+                        "agent_status"
+                      ],
+                      "type": "string"
+                    },
+                    "title": "Config",
+                    "type": "array"
+                  },
+                  "encoding": {
+                    "description": "kafka编码方式",
+                    "enum": [
+                      "GBK",
+                      "UTF-8"
+                    ],
+                    "title": "Encoding",
+                    "type": "string"
+                  },
+                  "host": {
+                    "description": "kafka服务器地址",
+                    "minLength": 1,
+                    "title": "Host",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "配置的ID",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "password": {
+                    "default": "",
+                    "description": "密码",
+                    "title": "Password",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "kafka服务器端口",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "title": "Port",
+                    "type": "integer"
+                  },
+                  "topic_name": {
+                    "description": "topic名称",
+                    "minLength": 1,
+                    "title": "Topic Name",
+                    "type": "string"
+                  },
+                  "username": {
+                    "default": "",
+                    "description": "用户名",
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "topic_name",
+                  "host",
+                  "port",
+                  "encoding",
+                  "ack_type",
+                  "config"
+                ],
+                "title": "KafkaConfigDetail",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改kafka配置信息",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/log/system_log/list": {
+      "post": {
+        "operationId": "system_log_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "log_types": {
+                    "default": [],
+                    "description": "系统日志类型, 1 表示系统负载，2 表示docker状态，3 表示探针状态",
+                    "items": {
+                      "enum": [
+                        1,
+                        2,
+                        3,
+                        4
+                      ],
+                      "type": "integer"
+                    },
+                    "title": "Log Types",
+                    "type": "array"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  }
+                },
+                "title": "SystemLogListArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/SystemLogRet"
+                        }
+                      ],
+                      "default": [],
+                      "description": "系统日志的列表信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ListSystemLogRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "系统日志的列表信息",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/log/system_log/delete": {
+      "post": {
+        "operationId": "system_log_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "时间筛选类请求的通用模式",
+                "properties": {
+                  "ids": {
+                    "default": [],
+                    "description": "要删除的id列表",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "log_types": {
+                    "default": [],
+                    "description": "系统日志类型, 1 表示系统负载，2 表示docker状态，3 表示探针状态",
+                    "items": {
+                      "enum": [
+                        1,
+                        2,
+                        3,
+                        4
+                      ],
+                      "type": "integer"
+                    },
+                    "title": "Log Types",
+                    "type": "array"
+                  },
+                  "not_after": {
+                    "description": "结束时间",
+                    "format": "date-time",
+                    "title": "Not After",
+                    "type": "string"
+                  },
+                  "not_before": {
+                    "description": "起始时间",
+                    "format": "date-time",
+                    "title": "Not Before",
+                    "type": "string"
+                  }
+                },
+                "title": "SystemLogDelArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "删除系统日志返回信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SystemLogDelRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除系统日志的列表信息",
+        "tags": [
+          "Syslog 管理与系统日志"
+        ]
+      }
+    },
+    "/api/account/logout": {
+      "post": {
+        "operationId": "logout",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "退出登录",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "LogoutRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "用户登出",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/manage/user/list": {
+      "post": {
+        "operationId": "list_users",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Abstract base class for generic types.\n\nA generic type is typically declared by inheriting from\nthis class parameterized with one or more type variables.\nFor example, a generic mapping type might be defined as::\n\n  class Mapping(Generic[KT, VT]):\n      def __getitem__(self, key: KT) -> VT:\n          ...\n      # Etc.\n\nThis class can then be used as follows::\n\n  def lookup_name(mapping: Mapping[KT, VT], key: KT, default: VT) -> VT:\n      try:\n          return mapping[key]\n      except KeyError:\n          return default",
+                  "properties": {
+                    "data": {
+                      "default": {},
+                      "description": "返回字典类型的数据",
+                      "title": "Data",
+                      "type": "object"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ManageUserListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "用户列表",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/manage/user/query": {
+      "post": {
+        "operationId": "query_user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "username": {
+                    "default": "",
+                    "description": "用户姓名",
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "title": "ManageUserQueryArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ManageUserListDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "用户列表",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ManageUserQueryRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "查询系统用户",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/manage/user/create": {
+      "post": {
+        "operationId": "create_user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ip_policy": {
+                    "description": "用户的IP策略",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ip Policy",
+                    "type": "array"
+                  },
+                  "ip_policy_mode": {
+                    "description": "用户IP策略模式",
+                    "title": "Ip Policy Mode",
+                    "type": "string"
+                  },
+                  "login_method": {
+                    "description": "用户登录方式",
+                    "title": "Login Method",
+                    "type": "string"
+                  },
+                  "password": {
+                    "description": "用户密码的Hash值",
+                    "title": "Password",
+                    "type": "string"
+                  },
+                  "role": {
+                    "description": "用户角色",
+                    "title": "Role",
+                    "type": "string"
+                  },
+                  "session_timeout": {
+                    "default": 0,
+                    "description": "用户会话过期时间",
+                    "maximum": 604800,
+                    "minimum": 0,
+                    "title": "Session Timeout",
+                    "type": "integer"
+                  },
+                  "sso_user": {
+                    "default": false,
+                    "description": "单点登陆用户",
+                    "title": "Sso User",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "用户姓名",
+                    "maxLength": 30,
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "username",
+                  "login_method",
+                  "password",
+                  "ip_policy",
+                  "ip_policy_mode",
+                  "role"
+                ],
+                "title": "ManageUserCreateArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ManageUserListDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "用户列表",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ManageUserCreateRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建系统用户",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/manage/user/modify": {
+      "post": {
+        "operationId": "modify_user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ip_policy": {
+                    "description": "用户的IP策略",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ip Policy",
+                    "type": "array"
+                  },
+                  "ip_policy_mode": {
+                    "description": "用户IP策略模式",
+                    "title": "Ip Policy Mode",
+                    "type": "string"
+                  },
+                  "login_method": {
+                    "description": "用户登录方式",
+                    "title": "Login Method",
+                    "type": "string"
+                  },
+                  "password": {
+                    "description": "用户密码的Hash值",
+                    "title": "Password",
+                    "type": "string"
+                  },
+                  "role": {
+                    "description": "用户角色",
+                    "title": "Role",
+                    "type": "string"
+                  },
+                  "session_timeout": {
+                    "default": 0,
+                    "description": "用户会话过期时间",
+                    "maximum": 604800,
+                    "minimum": 0,
+                    "title": "Session Timeout",
+                    "type": "integer"
+                  },
+                  "sso_user": {
+                    "default": false,
+                    "description": "单点登陆用户",
+                    "title": "Sso User",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "用户姓名",
+                    "maxLength": 30,
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "username",
+                  "login_method",
+                  "password",
+                  "ip_policy",
+                  "ip_policy_mode",
+                  "role"
+                ],
+                "title": "ManageUserModifyArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ManageUserListDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "用户列表",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ManageUserModifyRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改系统用户",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/manage/user/batch_delete": {
+      "post": {
+        "operationId": "batch_delete_user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "username_list": {
+                    "description": "批量删除账号",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Username List",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "username_list"
+                ],
+                "title": "BatchDeleteAccountArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "批量删除账号成功",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "BatchDeleteAccountRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "批量删除系统用户",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/manage/user/unlock_batch": {
+      "post": {
+        "operationId": "unlock_user_batch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "username_list": {
+                    "description": "待解除登录限制的用户的用户名",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Username List",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "username_list"
+                ],
+                "title": "UnlockUserBatchArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "实际解锁的用户数量",
+                      "minimum": 0,
+                      "title": "Data",
+                      "type": "integer"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "UnlockUserBatchRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "解除用户限制",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/profile/api_token": {
+      "post": {
+        "operationId": "api_token_api",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ManageUserListDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "生成api_token",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UserApiTokenRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取Api-Token",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/profile/get": {
+      "post": {
+        "operationId": "get_user_profile",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetUserProfileDetail"
+                        }
+                      ],
+                      "description": "获取用户信息详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetUserProfileRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取系统用户详细信息",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/profile/password/modify": {
+      "post": {
+        "operationId": "modify_password",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "old_password": {
+                    "description": "当前用户的旧密码",
+                    "title": "Old Password",
+                    "type": "string"
+                  },
+                  "password": {
+                    "description": "当前用户的新密码",
+                    "title": "Password",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "password",
+                  "old_password"
+                ],
+                "title": "UserChangePasswordArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ManageUserListDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "用户修改密码",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UserChangePasswordRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "系统用户修改密码",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/profile/policy/modify": {
+      "post": {
+        "operationId": "modify_policy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ip_policy": {
+                    "description": "用户的IP策略",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ip Policy",
+                    "type": "array"
+                  },
+                  "ip_policy_mode": {
+                    "default": "",
+                    "description": "用户IP策略模式",
+                    "enum": [
+                      "allow",
+                      "deny"
+                    ],
+                    "title": "Ip Policy Mode"
+                  }
+                },
+                "required": [
+                  "ip_policy"
+                ],
+                "title": "UserIpPolicyArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ManageUserListDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "用户修改IP策略",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UserIpPolicyRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改系统用户IP策略",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/profile/login_method/modify": {
+      "post": {
+        "operationId": "modify_Login_method",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ldap_search_base": {
+                    "description": "ldap",
+                    "title": "Ldap Search Base",
+                    "type": "string"
+                  },
+                  "login_method": {
+                    "description": "用户登录方式",
+                    "title": "Login Method",
+                    "type": "string"
+                  },
+                  "old_password": {
+                    "default": "",
+                    "description": "旧密码",
+                    "title": "Old Password",
+                    "type": "string"
+                  },
+                  "password": {
+                    "default": "",
+                    "description": "密码",
+                    "title": "Password",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "login_method"
+                ],
+                "title": "UserChangeLoginMethodArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/UserChangeLoginMethod"
+                        }
+                      ],
+                      "default": "",
+                      "description": "用户修改登录方式",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "UserChangeLoginMethodRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改系统用户登陆方式",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/profile/session_timeout/modify": {
+      "post": {
+        "operationId": "modify_session_timeout",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "session_timeout": {
+                    "description": "用户会话过期时间",
+                    "maximum": 604800,
+                    "minimum": 0,
+                    "title": "Session Timeout",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "session_timeout"
+                ],
+                "title": "UserSessionTimeoutArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ManageUserListDetail"
+                        }
+                      ],
+                      "description": "设置会话过期时间",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "UserSessionTimeoutRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "设置系统用户会话过期时间",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/profile/totp/generate": {
+      "post": {
+        "operationId": "generate_totp_secret_key",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "Base32编码格式的secret key，形如\"XSQJWGWBLIGC6B7U\"",
+                      "title": "Data",
+                      "type": "string"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GenerateTotpSecretKeyRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成TOTP验证私钥",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/profile/totp/active": {
+      "post": {
+        "operationId": "active_totp_secret_key",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "token": {
+                    "description": "当前时间的TOTP Token",
+                    "title": "Token",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "token"
+                ],
+                "title": "ActiveTotpSecretKeyArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "激活成功与否，如果之前已经激活成功，直接返回True",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ActiveTotpSecretKeyRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "开启TOTP验证",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/profile/totp/turn_off": {
+      "post": {
+        "operationId": "turn_off_totp",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "token": {
+                    "description": "当前时间的TOTP Token",
+                    "title": "Token",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "token"
+                ],
+                "title": "TurnOffTotpArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "关闭TOTP验证成功，如果之前已经关闭，直接返回True",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "TurnOffTotpRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "关闭TOTP验证",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/manage/user/manage_config/get": {
+      "post": {
+        "operationId": "get_user_manage_config",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/UserManageConfigDetail"
+                        }
+                      ],
+                      "description": "系统用户管理",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetUserManageConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "用户登陆相关管理",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/manage/user/manage_config/modify": {
+      "post": {
+        "operationId": "modify_user_manage_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error_count": {
+                    "description": "新的允许登录的最大失败次数",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "Error Count",
+                    "type": "integer"
+                  },
+                  "lock_time": {
+                    "description": "新的账号禁用分钟数",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "Lock Time",
+                    "type": "integer"
+                  },
+                  "password_timeout": {
+                    "description": "新的提示密码修改的天数，为0时表示不提示",
+                    "minimum": 0,
+                    "title": "Password Timeout",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "lock_time",
+                  "error_count",
+                  "password_timeout"
+                ],
+                "title": "ModifyUserManageConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/UserManageConfigDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "修改用户登录尝试次数限制",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ModifyUserManageConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改用户登录尝试次数限制",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/guide/update": {
+      "post": {
+        "operationId": "update_user_guide",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "guide": {
+                    "description": "用户引导数据列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Guide",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "guide"
+                ],
+                "title": "UpdateGuideArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新用户引导数据",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/radius_cfg/get": {
+      "post": {
+        "operationId": "get_radius_cfg",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/RadiusConfigDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "radius配置信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetRadiusCfgRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取radius配置信息",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/ldap_cfg/get": {
+      "post": {
+        "operationId": "get_ldap_cfg",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/LdapConfigDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "Ldap配置信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetLdapCfgRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取Ldap配置信息",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/radius_cfg/set": {
+      "post": {
+        "operationId": "set_radius_cfg",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "auth_type": {
+                    "description": "radius authtype",
+                    "title": "Auth Type",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "radius 端口",
+                    "title": "Port",
+                    "type": "integer"
+                  },
+                  "secret": {
+                    "description": "radius secret",
+                    "title": "Secret",
+                    "type": "string"
+                  },
+                  "server": {
+                    "description": "radius 服务器ip 域名",
+                    "title": "Server",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "server",
+                  "port",
+                  "secret",
+                  "auth_type"
+                ],
+                "title": "RadiusConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/RadiusConfigDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "用配置radius登录配置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "RadiusConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改radius配置",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/ldap_cfg/set": {
+      "post": {
+        "operationId": "set_ldap_cfg",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "admin_dn": {
+                    "description": "ldap admin_dn",
+                    "title": "Admin Dn",
+                    "type": "string"
+                  },
+                  "admin_passwd": {
+                    "description": "ldap authtype",
+                    "title": "Admin Passwd",
+                    "type": "string"
+                  },
+                  "base_dn": {
+                    "description": "ldap base_dn",
+                    "title": "Base Dn",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "ldap 端口",
+                    "title": "Port",
+                    "type": "integer"
+                  },
+                  "server": {
+                    "description": "ldap 服务器ip 域名",
+                    "title": "Server",
+                    "type": "string"
+                  },
+                  "user_key": {
+                    "description": "ldap user key, like cn",
+                    "title": "User Key",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "server",
+                  "port",
+                  "admin_dn",
+                  "base_dn",
+                  "admin_passwd",
+                  "user_key"
+                ],
+                "title": "LdapConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/LdapConfigDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "用户配置ldap登录配置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "LdapConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "修改ldap配置",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/account/api_token/get": {
+      "post": {
+        "operationId": "get_api_token",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "datav_user api_token",
+                      "title": "Data",
+                      "type": "string"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "enum": [
+                        "bad_parameters",
+                        "delete_self",
+                        "empty_password",
+                        "weak_password",
+                        "generate_cert_fail",
+                        "invalid_cert",
+                        "invalid_ip_policy",
+                        "invalid_parameter",
+                        "invalid_permissions",
+                        "invalid_user_role",
+                        "invalid_request",
+                        "ip_not_allowed",
+                        "license_expired",
+                        "bad-license-format",
+                        "invalid-license",
+                        "license_not_exists",
+                        "login_method_wrong",
+                        "login_required",
+                        "no_cert",
+                        "no_such_cert",
+                        "no_such_user",
+                        "permission_denied",
+                        "server_error",
+                        "short_password",
+                        "user_is_locked",
+                        "username_occupied",
+                        "username_too_long",
+                        "wrong_password_or_username",
+                        "totp_required",
+                        "wrong_totp_token",
+                        "totp_is_active",
+                        "not_found",
+                        "duplicate",
+                        "bad_format_filename",
+                        "upload_fs_wrong",
+                        "file_not_exist",
+                        "bad_radius_cofig",
+                        "bad_ldap_cofig",
+                        "method_not_implement",
+                        "sso_token_invalid"
+                      ],
+                      "title": "Err"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DatavUserTokenRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取datav_user Api-Token",
+        "tags": [
+          "用户信息"
+        ]
+      }
+    },
+    "/api/license/get_license_info": {
+      "post": {
+        "operationId": "get_license_info",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/LicenseInfo"
+                        }
+                      ],
+                      "description": "证书信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "GetLicenseInfoRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "检测许可证状态",
+        "tags": [
+          "许可证信息"
+        ]
+      }
+    },
+    "/api/report/list": {
+      "post": {
+        "operationId": "event_report_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "可选分页类请求的通用模式",
+                "properties": {
+                  "create_method": {
+                    "default": [],
+                    "description": "报告创建方式，为空时不进行过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Create Method",
+                    "type": "array"
+                  },
+                  "creator": {
+                    "default": [],
+                    "description": "报告创建者列表，为空时不进行过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Creator",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "报告ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "limit": {
+                    "description": "最多返回k个满足条件的数据，为None时表示不限制数量",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "limit",
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "跳过前k个满足条件的数据",
+                    "minimum": 0,
+                    "title": "offset",
+                    "type": "integer"
+                  },
+                  "report_name": {
+                    "default": [],
+                    "description": "报告名字列表，为空时不进行过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Report Name",
+                    "type": "array"
+                  },
+                  "report_type": {
+                    "default": [],
+                    "description": "报告创建类型，为空时不进行过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Report Type",
+                    "type": "array"
+                  }
+                },
+                "title": "EventReportListArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "description": "实际返回的数据",
+                      "items": {
+                        "$ref": "#/components/schemas/EventReportDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "total": {
+                      "description": "满足条件的记录总数",
+                      "minimum": 0,
+                      "title": "Total",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total",
+                    "data"
+                  ],
+                  "title": "EventReportListRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "报告管理列表",
+        "tags": [
+          "报告管理"
+        ]
+      }
+    },
+    "/api/report/create": {
+      "post": {
+        "operationId": "event_report_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "end_time": {
+                    "description": "报告的结束时间",
+                    "format": "date-time",
+                    "title": "End Time",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "报告的名称",
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "node": {
+                    "description": "节点ID，字符串为空时不对此项做筛选",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "report_type": {
+                    "description": "报告的类型",
+                    "title": "Report Type",
+                    "type": "string"
+                  },
+                  "start_time": {
+                    "description": "报告的开始时间",
+                    "format": "date-time",
+                    "title": "Start Time",
+                    "type": "string"
+                  },
+                  "tenant_ids": {
+                    "default": [],
+                    "description": "租户id",
+                    "items": {},
+                    "title": "Tenant Ids",
+                    "type": "array"
+                  },
+                  "timing": {
+                    "default": false,
+                    "description": "是否是定时任务请求生成报告，默认false",
+                    "title": "Timing",
+                    "type": "boolean"
+                  },
+                  "unit": {
+                    "default": 3600,
+                    "description": "报告时间轴粒度",
+                    "title": "Unit",
+                    "type": "integer"
+                  }
+                },
+                "title": "EventReportCreateArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/EventReportDetail"
+                        }
+                      ],
+                      "description": "报告详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "EventReportCreateRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建自定义报告",
+        "tags": [
+          "报告管理"
+        ]
+      }
+    },
+    "/api/report/portrait/create": {
+      "post": {
+        "operationId": "portrait_report_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "end_time": {
+                    "description": "报告的结束时间",
+                    "format": "date-time",
+                    "title": "End Time",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "报告的名称",
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "start_time": {
+                    "description": "报告的开始时间",
+                    "format": "date-time",
+                    "title": "Start Time",
+                    "type": "string"
+                  }
+                },
+                "title": "PortraitReportCreateArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/EventReportDetail"
+                        }
+                      ],
+                      "description": "报告详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "EventReportCreateRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建溯源报告",
+        "tags": [
+          "报告管理"
+        ]
+      }
+    },
+    "/api/report/portrait/info": {
+      "post": {
+        "operationId": "get_portrait_report",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "rid": {
+                    "description": "报告的id",
+                    "title": "Rid",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "rid"
+                ],
+                "title": "GetPortraitReportArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PortraitReportInfo"
+                        }
+                      ],
+                      "description": "报告详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetPortraitReportRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取溯源报告信息",
+        "tags": [
+          "报告管理"
+        ]
+      }
+    },
+    "/api/report/delete": {
+      "post": {
+        "operationId": "event_report_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "create_method": {
+                    "default": [],
+                    "description": "报告创建方式，为空时不进行过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Create Method",
+                    "type": "array"
+                  },
+                  "creator": {
+                    "default": [],
+                    "description": "报告创建者列表，为空时不进行过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Creator",
+                    "type": "array"
+                  },
+                  "ids": {
+                    "default": [],
+                    "description": "报告ID列表，列表为空时不对此项做过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  },
+                  "report_name": {
+                    "default": [],
+                    "description": "报告名字列表，为空时不进行过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Report Name",
+                    "type": "array"
+                  },
+                  "report_type": {
+                    "default": [],
+                    "description": "报告创建类型，为空时不进行过滤",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Report Type",
+                    "type": "array"
+                  }
+                },
+                "title": "EventReportListFilter",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除报告管理",
+        "tags": [
+          "报告管理"
+        ]
+      }
+    },
+    "/api/report/config/set": {
+      "post": {
+        "operationId": "report_config_set",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cfg": {
+                    "description": "定时生成报告设置",
+                    "items": {
+                      "$ref": "#/components/schemas/ReportConfigDetail"
+                    },
+                    "title": "Cfg",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "cfg"
+                ],
+                "title": "ReportConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "获取定时生成报告设置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ReportConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "定时生成报告配置",
+        "tags": [
+          "报告管理"
+        ]
+      }
+    },
+    "/api/report/config/get": {
+      "post": {
+        "operationId": "report_config_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": "",
+                      "description": "获取生成报告配置",
+                      "items": {
+                        "$ref": "#/components/schemas/ReportConfigDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ReportConfigGetRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取生成报告配置",
+        "tags": [
+          "报告管理"
+        ]
+      }
+    },
+    "/api/report/honeypot/create": {
+      "post": {
+        "operationId": "honeypot_report_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "end_time": {
+                    "description": "报告的结束时间",
+                    "format": "date-time",
+                    "title": "End Time",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "报告的名称",
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "start_time": {
+                    "description": "报告的开始时间",
+                    "format": "date-time",
+                    "title": "Start Time",
+                    "type": "string"
+                  }
+                },
+                "title": "HoneyPotDataReportCreateArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/EventReportDetail"
+                        }
+                      ],
+                      "description": "报告详情",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "EventReportCreateRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建蜜罐运营数据报告",
+        "tags": [
+          "报告管理"
+        ]
+      }
+    },
+    "/api/meta/agent/update_info": {
+      "post": {
+        "operationId": "get_agent_update_info",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/AgentUpdateInfoDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "获取探针更新信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "AgentUpdateInfoRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取探针更新信息",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/disk_stat": {
+      "post": {
+        "operationId": "mg_disk_stat",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MgDiskStatDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "获取主机磁盘状态",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MgDiskStatRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取主机磁盘状态",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/cpumem_stat": {
+      "post": {
+        "operationId": "host_cpumem_stat",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/CpuMemStatDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "获取主机cpu和内存使用率",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "HostCpuMemStatRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取主机cpu和内存使用率",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/delete_logo": {
+      "post": {
+        "operationId": "delete_logo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "default": "",
+                      "description": "删除logo",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DeleteLogoRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除logo",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/system_time/fetch": {
+      "post": {
+        "operationId": "get_system_time",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "current_time": {
+                      "description": "系统当前时间",
+                      "format": "date-time",
+                      "title": "Current Time",
+                      "type": "string"
+                    },
+                    "up_time": {
+                      "description": "系统已经运行时间",
+                      "title": "Up Time",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "current_time",
+                    "up_time"
+                  ],
+                  "title": "FetchSystemTimeInfoRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取系统时间信息",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/system_time/update": {
+      "post": {
+        "operationId": "update_system_time",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "time": {
+                    "description": "更改后的时间",
+                    "format": "date-time",
+                    "title": "Time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "time"
+                ],
+                "title": "UpdateSystemTimeInfoArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "success": {
+                      "default": true,
+                      "description": "请求成功",
+                      "title": "Success",
+                      "type": "boolean"
+                    }
+                  },
+                  "title": "MinimumRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新系统时间",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/snmp/get": {
+      "post": {
+        "operationId": "get_snmp",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "GetSNMPArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/SNMPServiceConfig"
+                        }
+                      ],
+                      "description": "snmp配置数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetSNMPRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取SNMP服务信息返回",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/snmp/set": {
+      "post": {
+        "operationId": "set_snmp",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "allow_oids": {
+                    "default": [],
+                    "description": "允许访问的oid",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Allow Oids",
+                    "type": "array"
+                  },
+                  "allowed_ips": {
+                    "default": [],
+                    "description": "允许访问的ip, 这个字段暂时没用",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Allowed Ips",
+                    "type": "array"
+                  },
+                  "port": {
+                    "default": 161,
+                    "description": "snmp端口",
+                    "title": "Port",
+                    "type": "integer"
+                  },
+                  "v1v2c_auth_method": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/SNMPV1V2CAuthMethod"
+                      }
+                    ],
+                    "description": "v1v2登陆设置",
+                    "title": "V1V2C Auth Method"
+                  },
+                  "v3_auth_method": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/SNMPV3AuthMethod"
+                      }
+                    ],
+                    "description": "v3登陆设置",
+                    "title": "V3 Auth Method"
+                  }
+                },
+                "title": "SetSNMPServersArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SetSNMPRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "设置SNMP服务的返回",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/package/info": {
+      "post": {
+        "operationId": "get_package_info",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "GetPackageInfoArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PackageInfoRet"
+                        }
+                      ],
+                      "description": "Package信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetPackageInfoRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "升级包信息",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/package/apply": {
+      "post": {
+        "operationId": "apply_package",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "package_id": {
+                    "description": "升级包ID",
+                    "title": "Package Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "package_id"
+                ],
+                "title": "ApplyPackageInfoArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ApplyPackageInfoRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "升级应用包",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/package/delete": {
+      "post": {
+        "operationId": "del_package",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "package_id": {
+                    "description": "升级包ID",
+                    "title": "Package Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "package_id"
+                ],
+                "title": "DelPackageInfoArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DelPackageInfoRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除应用包",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/package/action/list": {
+      "post": {
+        "operationId": "fetch_package_actions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "package_id": {
+                    "description": "升级包ID",
+                    "title": "Package Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "package_id"
+                ],
+                "title": "FetchPackageActionsArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "升级动作信息列表",
+                      "items": {
+                        "$ref": "#/components/schemas/PackageAction"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "FetchPackageActionsRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取升级平台的升级包信息",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/upstream_package/fetch": {
+      "post": {
+        "operationId": "fetch_upstream_package",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "QueryUpstreamPackageArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "上游Package信息",
+                      "items": {
+                        "$ref": "#/components/schemas/UpstreamPackageBaseInfoRet"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "QueryUpstreamPackageRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "刷新升级平台的升级包信息",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/upstream_package/list": {
+      "post": {
+        "operationId": "list_upstream_package",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "QueryUpstreamPackageArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "上游Package信息",
+                      "items": {
+                        "$ref": "#/components/schemas/UpstreamPackageBaseInfoRet"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "QueryUpstreamPackageRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取升级平台的升级包信息",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/upstream_package/download": {
+      "post": {
+        "operationId": "download_upstream_package",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "description": "升级包ID",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "title": "DownloadUpstreamPackageArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DownloadUpstreamPackageRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "下载升级平台的升级包",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/backup/list": {
+      "post": {
+        "operationId": "list_backup_list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "ListBackupArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "数据列表",
+                      "items": {
+                        "$ref": "#/components/schemas/BackupBaseInfoRet"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ListBackupRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "备份数据列表",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/backup/create": {
+      "post": {
+        "operationId": "create_backup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "comment": {
+                    "description": "备注",
+                    "title": "Comment",
+                    "type": "string"
+                  },
+                  "types": {
+                    "default": [],
+                    "description": "备份类型",
+                    "items": {
+                      "enum": [
+                        "user",
+                        "honeypot",
+                        "agent",
+                        "config"
+                      ]
+                    },
+                    "title": "Types",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "comment"
+                ],
+                "title": "StartBackupArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "StartBackupRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建备份数据",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/backup/info": {
+      "post": {
+        "operationId": "backup_info",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "数据ID",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "QueryBackupArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/BackupBaseInfoRet"
+                        }
+                      ],
+                      "description": "信息列表",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "QueryBackupRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "查看备份详情",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/backup/delete": {
+      "post": {
+        "operationId": "delete_backup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "default": [],
+                    "description": "备份包ID",
+                    "items": {
+                      "format": "uuid",
+                      "type": "string"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "title": "DelBackupArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "DelBackupRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除备份数据",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/backup/store": {
+      "post": {
+        "operationId": "store_backup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "数据ID",
+                    "title": "Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "RestoreBackupArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "RestoreBackupRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "还原备份数据",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/threatcfg/get": {
+      "post": {
+        "operationId": "get_threat_cfg",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ThreatCfgInfo"
+                        }
+                      ],
+                      "description": "获取威胁情报配置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ThreatCfgRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取威胁情报配置",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/threatcfg/set": {
+      "post": {
+        "operationId": "set_threat_cfg",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "access_key": {
+                    "description": "access key id",
+                    "title": "Access Key",
+                    "type": "string"
+                  },
+                  "enable": {
+                    "description": "开启威胁情报",
+                    "title": "Enable",
+                    "type": "boolean"
+                  },
+                  "secret": {
+                    "description": "access secret",
+                    "title": "Secret",
+                    "type": "string"
+                  },
+                  "source": {
+                    "description": "数据来源",
+                    "title": "Source",
+                    "type": "string"
+                  },
+                  "token": {
+                    "description": "token",
+                    "title": "Token",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "enable",
+                  "source"
+                ],
+                "title": "SetThreatArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ThreatCfgInfo"
+                        }
+                      ],
+                      "description": "获取威胁情报配置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ThreatCfgRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "设置威胁情报配置",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/wenjin/get": {
+      "post": {
+        "operationId": "get_wenjin_cfg",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/WenjinCfgInfo"
+                        }
+                      ],
+                      "description": "获取问津配置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "WenjinCfgRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取问津配置",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/wenjin/set": {
+      "post": {
+        "operationId": "set_wenjin_cfg",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "address": {
+                    "description": "问津地址",
+                    "title": "Address",
+                    "type": "string"
+                  },
+                  "token": {
+                    "description": "问津token",
+                    "title": "Token",
+                    "type": "string"
+                  }
+                },
+                "title": "SetWenjinArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/WenjinCfgInfo"
+                        }
+                      ],
+                      "description": "获取问津配置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "WenjinCfgRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "设置问津配置",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/webshell/config/info": {
+      "post": {
+        "operationId": "get_webshell_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "QueryWebshellConfigArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "配置信息",
+                      "items": {
+                        "$ref": "#/components/schemas/WebshellConfigInfo"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "QueryWebshellConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "查看webshell探针地址配置",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/webshell/config/update": {
+      "post": {
+        "operationId": "update_webshell_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "configs": {
+                    "description": "配置信息",
+                    "items": {
+                      "$ref": "#/components/schemas/WebshellConfigInfo"
+                    },
+                    "title": "Configs",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "configs"
+                ],
+                "title": "UpdateWebshellConfigArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "最小化响应的通用模式\n\n使用该类型作为返回值的API view，一般不会失败(诸如login_required等错误不包含在内)",
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinimumRet2",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新webshell探针地址配置",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/meta/retry/patch": {
+      "post": {
+        "operationId": "retry_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "node": {
+                    "description": "节点sn",
+                    "title": "Node",
+                    "type": "string"
+                  },
+                  "package_id": {
+                    "description": "升级包ID",
+                    "title": "Package Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "package_id",
+                  "node"
+                ],
+                "title": "ReApplyPackageInfoArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ApplyPackageInfoRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "升级应用包",
+        "tags": [
+          "系统配置与系统信息"
+        ]
+      }
+    },
+    "/api/management/partition/cfg/get": {
+      "post": {
+        "operationId": "get_partition_cfg",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "model_label": {
+                    "description": "表名称",
+                    "title": "Model Label",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "model_label"
+                ],
+                "title": "GetPartitionConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PartitionConfigDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "分区表配置信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "PartitionConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "获取日志归档配置",
+        "tags": [
+          "日志归档管理"
+        ]
+      }
+    },
+    "/api/management/partition/cfg/set": {
+      "post": {
+        "operationId": "get_partition_cfg",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "attach_tablespace": {
+                    "description": "正常表空间",
+                    "title": "Attach Tablespace",
+                    "type": "string"
+                  },
+                  "detach_tablespace": {
+                    "description": "归档表空间",
+                    "title": "Detach Tablespace",
+                    "type": "string"
+                  },
+                  "id": {
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "interval": {
+                    "description": "归档间隔",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "title": "Interval",
+                    "type": "integer"
+                  },
+                  "period": {
+                    "description": "分表周期",
+                    "title": "Period",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "period"
+                ],
+                "title": "SetPartitionConfigArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PartitionConfigDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "分区表配置信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "PartitionConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "设置日志归档配置",
+        "tags": [
+          "日志归档管理"
+        ]
+      }
+    },
+    "/api/management/partition/log/delete": {
+      "post": {
+        "operationId": "delete_partition_log",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "PartitionlogArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "通用模式",
+                  "properties": {
+                    "data": {
+                      "title": "Data",
+                      "type": "string"
+                    },
+                    "err": {
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MinRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除归档日志",
+        "tags": [
+          "日志归档管理"
+        ]
+      }
+    },
+    "/api/management/partition/log/set": {
+      "post": {
+        "operationId": "set_partition_log",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "attach": {
+                    "default": true,
+                    "description": "不归档 True, 归档 False",
+                    "title": "Attach",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Id",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "SetPartitionlogArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "通用模式",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/SetPartitionlogRetData"
+                    },
+                    "err": {
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "SetPartitionlogRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "归档/恢复 日志",
+        "tags": [
+          "日志归档管理"
+        ]
+      }
+    },
+    "/api/management/archive/download_token": {
+      "post": {
+        "operationId": "generate_archive_download_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ids": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "title": "Ids",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "ids"
+                ],
+                "title": "PartitionlogArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/GetArchiveFileIdDetail"
+                        }
+                      ],
+                      "default": "",
+                      "description": "下载归档信息",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "GetArchiveFileIdRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "生成归档日志下载凭证",
+        "tags": [
+          "日志归档管理"
+        ]
+      }
+    },
+    "/api/captain/node/identify": {
+      "post": {
+        "operationId": "identify_node",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "host": {
+                    "description": "node 地址",
+                    "title": "Host",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "node 名称",
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "sn": {
+                    "description": "node 序列号",
+                    "title": "Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "sn",
+                  "host"
+                ],
+                "title": "NodeIdentifyArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "api_port": {
+                      "description": "api 映射端口",
+                      "title": "Api Port",
+                      "type": "integer"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "node id",
+                      "title": "Id",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "node 名称",
+                      "title": "Name",
+                      "type": "string"
+                    },
+                    "pg_port": {
+                      "description": "pg 映射端口",
+                      "title": "Pg Port",
+                      "type": "integer"
+                    },
+                    "sw_port": {
+                      "description": "seaweedfs 映射端口",
+                      "title": "Sw Port",
+                      "type": "integer"
+                    },
+                    "upgrader_port": {
+                      "description": "upgrader 映射端口",
+                      "title": "Upgrader Port",
+                      "type": "integer"
+                    }
+                  },
+                  "title": "NodeIdentify",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "子节点认证",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/node/connect": {
+      "post": {
+        "operationId": "connect_node",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "node id",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "local_api_token": {
+                    "title": "Local Api Token",
+                    "type": "string"
+                  },
+                  "version": {
+                    "description": "版本信息",
+                    "title": "Version",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "version",
+                  "local_api_token"
+                ],
+                "title": "ConnectNodeArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ConnectNodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "子节点就绪通知",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/node/list": {
+      "post": {
+        "operationId": "list_node",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "title": "ListNodeArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "default": "",
+                      "description": "节点列表",
+                      "items": {
+                        "$ref": "#/components/schemas/NodeInfoDetail"
+                      },
+                      "title": "Data",
+                      "type": "array"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "ListNodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "子节点列表",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/node/create": {
+      "post": {
+        "operationId": "create_node",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "host": {
+                    "description": "node 地址",
+                    "title": "Host",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "node 名称",
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "sn": {
+                    "description": "node 序列号",
+                    "title": "Sn",
+                    "type": "string"
+                  },
+                  "token": {
+                    "description": "api token",
+                    "title": "Token",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "sn"
+                ],
+                "title": "NodeInfoCreateArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "data",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "NodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建子节点",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/node/update": {
+      "post": {
+        "operationId": "update_node",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "host": {
+                    "description": "node 地址",
+                    "title": "Host",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "node 名称",
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "sn": {
+                    "description": "node 序列号",
+                    "title": "Sn",
+                    "type": "string"
+                  },
+                  "token": {
+                    "description": "api token",
+                    "title": "Token",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "sn"
+                ],
+                "title": "NodeInfoCreateArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "data",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "NodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "更新子节点",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/node/delete": {
+      "post": {
+        "operationId": "delete_node",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "sn": {
+                    "description": "node sn",
+                    "title": "Sn",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sn"
+                ],
+                "title": "DeleteNodeArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "data",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "NodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "删除子节点",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/node/manual_sync": {
+      "post": {
+        "operationId": "manual_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "node id",
+                    "title": "Id",
+                    "type": "integer"
+                  },
+                  "tablename": {
+                    "description": "同步的表名, 逗号分隔",
+                    "title": "Tablename",
+                    "type": "string"
+                  },
+                  "version": {
+                    "description": "版本信息",
+                    "title": "Version",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "version"
+                ],
+                "title": "ManualSyncArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "data",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "NodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "触发同步某些表的数据",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/sync/create": {
+      "post": {
+        "operationId": "create_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "force": {
+                    "default": true,
+                    "description": "创建同步前同步数据",
+                    "title": "Force",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "node id",
+                    "title": "Id",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "CreateSyncArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "data",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "NodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "子节点创建同步",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/sync/drop": {
+      "post": {
+        "operationId": "drop_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "node id",
+                    "title": "Id",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "SyncArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "data",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "NodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "子节点删除同步，异常不易处理时，删除后重新创建可能解决问题",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/sync/start": {
+      "post": {
+        "operationId": "start_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "node id",
+                    "title": "Id",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "SyncArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "data",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "NodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "子节点启动同步",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/captain/sync/pause": {
+      "post": {
+        "operationId": "pause_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "description": "node id",
+                    "title": "Id",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "title": "SyncArg",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "data",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "NodeRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "子节点暂停同步, 用于异常状态调试",
+        "tags": [
+          "集中管理"
+        ]
+      }
+    },
+    "/api/intellectual/scan_agent/list": {
+      "post": {
+        "operationId": "list_agent",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "ListAgentRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "已授权且工作正常的探针列表",
+        "tags": [
+          "智学习"
+        ]
+      }
+    },
+    "/api/intellectual/scan_task/config": {
+      "post": {
+        "operationId": "scan_task_config",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ConfigDetail"
+                        }
+                      ],
+                      "description": "扫描任务配置",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "TaskConfigRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "扫描配置",
+        "tags": [
+          "智学习"
+        ]
+      }
+    },
+    "/api/intellectual/scan_task/list": {
+      "post": {
+        "operationId": "list_task",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "ListScanTaskRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "正在进行中的扫描任务列表",
+        "tags": [
+          "智学习"
+        ]
+      }
+    },
+    "/api/intellectual/scan_task/start": {
+      "post": {
+        "operationId": "start_scan_task",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "agent_args": {
+                    "description": "选中的探针信息",
+                    "items": {
+                      "$ref": "#/components/schemas/AgentArgs"
+                    },
+                    "title": "Agent Args",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "agent_args"
+                ],
+                "title": "ScanTaskArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "开始扫描任务",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "StartScanTaskRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "开始扫描任务",
+        "tags": [
+          "智学习"
+        ]
+      }
+    },
+    "/api/intellectual/scan_task/stop": {
+      "post": {
+        "operationId": "stop_scan_task",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "结束扫描任务",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "StopScanTaskRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "结束扫描任务",
+        "tags": [
+          "智学习"
+        ]
+      }
+    },
+    "/api/intellectual/scan_result/list": {
+      "post": {
+        "operationId": "list_result",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "分页类响应的通用模式",
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PageingRetBase_ItemType_"
+                        }
+                      ],
+                      "description": "包含记录总数和返回的列表数据",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "错误详细描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "title": "ScanResultRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "查询扫描结果",
+        "tags": [
+          "智学习"
+        ]
+      }
+    },
+    "/api/intellectual/recommend_service/create": {
+      "post": {
+        "operationId": "create_service",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "items": {
+                      "$ref": "#/components/schemas/CreateRecommendService"
+                    },
+                    "title": "Data",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "data"
+                ],
+                "title": "CreateServicesArgs",
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/MinimumRet"
+                        }
+                      ],
+                      "description": "创建所选服务",
+                      "title": "Data"
+                    },
+                    "err": {
+                      "default": "",
+                      "description": "错误信息",
+                      "title": "Err",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "default": "",
+                      "description": "具体错误信息描述",
+                      "title": "Msg",
+                      "type": "string"
+                    }
+                  },
+                  "title": "CreateServiceRet",
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "创建所选服务",
+        "tags": [
+          "智学习"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add D-Sensor as a chaitin-cli product command under `products/dsensor`
- wire dsensor into runtime config, env overrides, and root dry-run handling
- document dsensor config and usage in README files and config example

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `go run . --dry-run dsensor agent agent`
