### PR TITLE
fix(dsensor): use API-Token header instead of X-API-Key

### DIFF
--- a/products/dsensor/command.go
+++ b/products/dsensor/command.go
@@ -46,7 +46,7 @@ Commands are generated from the embedded OpenAPI schema and call D-Sensor APIs t
 	}
 
 	cmd.PersistentFlags().StringVar(&urlFlag, "url", "", "D-Sensor API URL")
-	cmd.PersistentFlags().StringVar(&apiKeyFlag, "api-key", "", "API token sent as X-API-Key header")
+	cmd.PersistentFlags().StringVar(&apiKeyFlag, "api-key", "", "API token sent as API-Token header")
 	cmd.PersistentFlags().BoolVar(&refreshCache, "refresh-cache", false, "Force refresh local server version cache")
 	cmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format (table|json)")
 	cmd.PersistentFlags().BoolVar(&insecureTLS, "insecure", false, "Skip TLS certificate verification")

--- a/products/dsensor/internal/client/client.go
+++ b/products/dsensor/internal/client/client.go
@@ -57,7 +57,7 @@ func (c *Client) Do(path string, body []byte) (*http.Response, []byte, error) {
 
 	req.Header.Set("Content-Type", "application/json")
 	if c.APIKey != "" {
-		req.Header.Set("X-API-Key", c.APIKey)
+		req.Header.Set("API-Token", c.APIKey)
 	}
 
 	resp, err := c.HTTPClient.Do(req)


### PR DESCRIPTION
Problem
-  When using chaitin-cli dsensor with an API token, authentication always fails with 401 login_required.

Root Cause
-   D-Sensor's server-side APITokenAuthMiddleware reads the API-Token header:
-   _Dsensor: account/middleware.py_
-   api_token = request.META.get("HTTP_API_TOKEN")
-   Django converts API-Token → HTTP_API_TOKEN. However, chaitin-cli was sending X-API-Key header, which maps to  HTTP_X_API_KEY — a different key that the middleware never reads.

Fix
- client.go: X-API-Key → API-Token
- command.go: Update flag description to match

 Verification
- Tested against a live D-Sensor (DS-S40-25.12.001_r2) instance — authentication works correctly after this fix.