### PR TITLE
Add monkeyscan scan command

### DIFF
--- a/products/monkeyscan/client.go
+++ b/products/monkeyscan/client.go
@@ -6,8 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -55,22 +59,119 @@ func (c *client) ReviewDetail(ctx context.Context, runID string) (*reviewDetail,
 	return &out, nil
 }
 
+func (c *client) CreateRepoScan(ctx context.Context, req scanCreateRequest) (*scanCreateResponse, error) {
+	var out scanCreateResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/cli/scans?type=repo", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *client) CreateArchiveScan(ctx context.Context, filePath, taskName string) (*scanCreateResponse, error) {
+	return c.CreateArchiveScanWithName(ctx, filePath, taskName, filepath.Base(filePath))
+}
+
+func (c *client) CreateArchiveScanWithName(ctx context.Context, filePath, taskName, fileName string) (*scanCreateResponse, error) {
+	reader, writer := io.Pipe()
+	form := multipart.NewWriter(writer)
+	go writeArchiveScanMultipart(writer, form, filePath, taskName, fileName)
+	var out scanCreateResponse
+	if err := c.do(ctx, http.MethodPost, "/api/v1/cli/scans?type=archive", reader, form.FormDataContentType(), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func writeArchiveScanMultipart(pipe *io.PipeWriter, form *multipart.Writer, filePath, taskName, fileName string) {
+	var err error
+	defer func() {
+		if err != nil {
+			_ = pipe.CloseWithError(err)
+			return
+		}
+		_ = pipe.Close()
+	}()
+	if strings.TrimSpace(taskName) != "" {
+		if err = form.WriteField("task_name", taskName); err != nil {
+			err = fmt.Errorf("写入任务名称失败: %w", err)
+			return
+		}
+	}
+	if strings.TrimSpace(fileName) != "" {
+		if err = form.WriteField("file_name", fileName); err != nil {
+			err = fmt.Errorf("写入文件名称失败: %w", err)
+			return
+		}
+	}
+	file, openErr := os.Open(filePath)
+	if openErr != nil {
+		err = fmt.Errorf("打开上传文件失败: %w", openErr)
+		return
+	}
+	defer file.Close()
+	part, createErr := form.CreateFormFile("file", filepath.Base(filePath))
+	if createErr != nil {
+		err = fmt.Errorf("创建上传表单失败: %w", createErr)
+		return
+	}
+	if _, err = io.Copy(part, file); err != nil {
+		err = fmt.Errorf("写入上传文件失败: %w", err)
+		return
+	}
+	if err = form.Close(); err != nil {
+		err = fmt.Errorf("关闭上传表单失败: %w", err)
+	}
+}
+
+func (c *client) ListScans(ctx context.Context) (*scanListResponse, error) {
+	var out scanListResponse
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v1/cli/scans", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *client) ScanResult(ctx context.Context, taskGroupID string, full bool) (*scanResultResponse, error) {
+	q := url.Values{}
+	if strings.TrimSpace(taskGroupID) != "" {
+		q.Set("task_group_id", strings.TrimSpace(taskGroupID))
+	}
+	if full {
+		q.Set("full", strconv.FormatBool(full))
+	}
+	path := "/api/v1/cli/scans/result"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	var out scanResultResponse
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 func (c *client) doJSON(ctx context.Context, method, path string, body any, out any) error {
 	var reqBody io.Reader
+	contentType := ""
 	if body != nil {
 		data, err := json.Marshal(body)
 		if err != nil {
 			return fmt.Errorf("编码请求失败: %w", err)
 		}
 		reqBody = bytes.NewReader(data)
+		contentType = "application/json"
 	}
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	return c.do(ctx, method, path, reqBody, contentType, out)
+}
+
+func (c *client) do(ctx context.Context, method, path string, body io.Reader, contentType string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
 	if err != nil {
 		return fmt.Errorf("创建请求失败: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.key)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -152,4 +253,36 @@ func isFailedReviewStatus(runStatus, groupStatus string) bool {
 		return true
 	}
 	return false
+}
+
+func waitScanResult(ctx context.Context, client *client, taskGroupID string, full bool) (*scanResultResponse, error) {
+	deadline := time.NewTimer(pollTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		result, err := client.ScanResult(ctx, taskGroupID, full)
+		if err != nil {
+			return nil, err
+		}
+		if isTerminalScanStatus(result.Task.Status) {
+			return result, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline.C:
+			return nil, fmt.Errorf("等待扫描结果超时")
+		case <-ticker.C:
+		}
+	}
+}
+
+func isTerminalScanStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "success", "failed", "partial_success":
+		return true
+	default:
+		return false
+	}
 }

--- a/products/monkeyscan/client.go
+++ b/products/monkeyscan/client.go
@@ -27,7 +27,7 @@ func newClient(baseURL, key string) *client {
 		baseURL: strings.TrimRight(baseURL, "/"),
 		key:     strings.TrimSpace(key),
 		httpClient: &http.Client{
-			Timeout: 60 * time.Second,
+			Timeout: 180 * time.Second,
 		},
 	}
 }

--- a/products/monkeyscan/command.go
+++ b/products/monkeyscan/command.go
@@ -195,6 +195,7 @@ func newScanCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "scan",
 		Short: "Run MonkeyScan full scan",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runScan(cmd, opts)
 		},
@@ -215,6 +216,7 @@ func newScanListCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List recent MonkeyScan full scan tasks",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runScanList(cmd)
 		},

--- a/products/monkeyscan/command.go
+++ b/products/monkeyscan/command.go
@@ -37,6 +37,7 @@ func NewCommand() *cobra.Command {
 	}
 	cmd.AddCommand(newAuthCommand())
 	cmd.AddCommand(newReviewCommand())
+	cmd.AddCommand(newScanCommand())
 	return cmd
 }
 
@@ -187,6 +188,166 @@ func newReviewStatusCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&run, "run", "", "Client run id, server run id, or local run directory")
 	return cmd
+}
+
+func newScanCommand() *cobra.Command {
+	opts := scanOptions{}
+	cmd := &cobra.Command{
+		Use:   "scan",
+		Short: "Run MonkeyScan full scan",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runScan(cmd, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Path, "path", "", "Source directory to package and scan")
+	cmd.Flags().StringVar(&opts.File, "file", "", "Archive file to upload and scan")
+	cmd.Flags().StringVar(&opts.Repo, "repo", "", "GitHub repository URL to scan")
+	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Repository branch for --repo")
+	cmd.Flags().BoolVar(&opts.Wait, "wait", false, "Wait for scan completion and print result")
+	cmd.Flags().BoolVar(&opts.Full, "full", false, "Print full scan report")
+	cmd.Flags().StringVar(&opts.Output, "output", "", "Write scan result to file")
+	cmd.AddCommand(newScanListCommand())
+	cmd.AddCommand(newScanResultCommand())
+	return cmd
+}
+
+func newScanListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List recent MonkeyScan full scan tasks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runScanList(cmd)
+		},
+	}
+}
+
+func newScanResultCommand() *cobra.Command {
+	opts := scanOptions{}
+	cmd := &cobra.Command{
+		Use:   "result [task_group_id]",
+		Short: "Fetch MonkeyScan full scan result",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.TaskGroupID = args[0]
+			}
+			return runScanResult(cmd, opts.TaskGroupID, opts.Full, opts.Output)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.Full, "full", false, "Print full scan report")
+	cmd.Flags().StringVar(&opts.Output, "output", "", "Write scan result to file")
+	return cmd
+}
+
+func runScan(cmd *cobra.Command, opts scanOptions) error {
+	if err := validateScanOptions(opts); err != nil {
+		return err
+	}
+	if dryRun {
+		fmt.Fprintf(cmd.OutOrStdout(), "MonkeyScan Scan Dry Run\n服务地址: %s\n", normalizedURL(runtimeCfg.URL))
+		return nil
+	}
+	client, err := authenticatedClient()
+	if err != nil {
+		return err
+	}
+	var resp *scanCreateResponse
+	if strings.TrimSpace(opts.Repo) != "" {
+		resp, err = client.CreateRepoScan(cmd.Context(), scanCreateRequest{
+			RepoURL:  opts.Repo,
+			Branch:   opts.Branch,
+			TaskName: "",
+		})
+	} else {
+		archivePath, cleanup, err := prepareScanArchive(opts)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		resp, err = client.CreateArchiveScanWithName(cmd.Context(), archivePath, scanArchiveTaskName(opts), scanArchiveFileName(opts))
+	}
+	if err != nil {
+		return err
+	}
+	printScanCreated(cmd, resp)
+	if !opts.Wait {
+		return nil
+	}
+	result, err := waitScanResult(cmd.Context(), client, resp.TaskGroupID, opts.Full)
+	if err != nil {
+		return err
+	}
+	return outputScanResult(cmd, result, opts.Output)
+}
+
+func runScanList(cmd *cobra.Command) error {
+	client, err := authenticatedClient()
+	if err != nil {
+		return err
+	}
+	resp, err := client.ListScans(cmd.Context())
+	if err != nil {
+		return err
+	}
+	printScanList(cmd, resp)
+	return nil
+}
+
+func runScanResult(cmd *cobra.Command, taskGroupID string, full bool, output string) error {
+	client, err := authenticatedClient()
+	if err != nil {
+		return err
+	}
+	resp, err := client.ScanResult(cmd.Context(), taskGroupID, full)
+	if err != nil {
+		return err
+	}
+	return outputScanResult(cmd, resp, output)
+}
+
+func validateScanOptions(opts scanOptions) error {
+	count := 0
+	for _, value := range []string{opts.Path, opts.File, opts.Repo} {
+		if strings.TrimSpace(value) != "" {
+			count++
+		}
+	}
+	if count > 1 {
+		return fmt.Errorf("--path、--file、--repo 只能指定一个")
+	}
+	if strings.TrimSpace(opts.Branch) != "" && strings.TrimSpace(opts.Repo) == "" {
+		return fmt.Errorf("--branch 仅支持和 --repo 一起使用")
+	}
+	return nil
+}
+
+func authenticatedClient() (*client, error) {
+	key, _ := resolveKey()
+	if key == "" {
+		return nil, fmt.Errorf("未配置 MonkeyScan CLI API Key，请先运行 monkeyscan auth set-key 或设置 %s", envAPIKeyName)
+	}
+	return newClient(normalizedURL(runtimeCfg.URL), key), nil
+}
+
+func scanArchiveTaskName(opts scanOptions) string {
+	if strings.TrimSpace(opts.File) != "" {
+		return strings.TrimSuffix(filepath.Base(opts.File), filepath.Ext(opts.File))
+	}
+	source := strings.TrimSpace(opts.Path)
+	if source == "" || source == "." {
+		if wd, err := os.Getwd(); err == nil {
+			return filepath.Base(wd)
+		}
+		return "local-source"
+	}
+	return filepath.Base(source)
+}
+
+func scanArchiveFileName(opts scanOptions) string {
+	if strings.TrimSpace(opts.File) != "" {
+		return filepath.Base(opts.File)
+	}
+	return scanArchiveTaskName(opts)
 }
 
 func runReview(cmd *cobra.Command, opts reviewScope) error {

--- a/products/monkeyscan/command_test.go
+++ b/products/monkeyscan/command_test.go
@@ -271,6 +271,19 @@ func TestValidateArchiveFileBodySizeRejectsOver100MB(t *testing.T) {
 	}
 }
 
+func TestRenderScanResultMarkdownShowsTruncatedNotice(t *testing.T) {
+	got := renderScanResultMarkdown(&scanResultResponse{
+		Task:      scanListItem{TaskGroupID: "group-1", Status: "success"},
+		Total:     5001,
+		Items:     []scanDefect{{ID: "defect-1", Severity: "critical"}},
+		Full:      true,
+		Truncated: true,
+	})
+	if !strings.Contains(got, "仅展示前 1 条") {
+		t.Fatalf("renderScanResultMarkdown() missing truncated notice:\n%s", got)
+	}
+}
+
 func TestScanCommandsRejectUnexpectedArgs(t *testing.T) {
 	tests := [][]string{
 		{"scan", "./repo"},

--- a/products/monkeyscan/command_test.go
+++ b/products/monkeyscan/command_test.go
@@ -71,6 +71,34 @@ func TestValidateReviewScope(t *testing.T) {
 	}
 }
 
+func TestValidateScanOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    scanOptions
+		wantErr string
+	}{
+		{name: "default path"},
+		{name: "path", opts: scanOptions{Path: "."}},
+		{name: "file", opts: scanOptions{File: "repo.zip"}},
+		{name: "repo branch", opts: scanOptions{Repo: "https://github.com/acme/repo", Branch: "main"}},
+		{name: "multiple sources", opts: scanOptions{Path: ".", File: "repo.zip"}, wantErr: "只能指定一个"},
+		{name: "branch without repo", opts: scanOptions{Branch: "main"}, wantErr: "--branch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateScanOptions(tt.opts)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("validateScanOptions() error = %v", err)
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("validateScanOptions() error = %v, want contains %q", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
 func TestClientHandlesStatusAndAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
@@ -115,6 +143,111 @@ func TestClientStatusFallsBackToReadyCompatibilityField(t *testing.T) {
 	}
 	if !status.Ready || !status.ReviewReady {
 		t.Fatalf("Status() = %+v, want ready and review_ready true", status)
+	}
+}
+
+func TestClientScanEndpoints(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		switch r.URL.Path {
+		case "/api/v1/cli/scans":
+			switch r.Method {
+			case http.MethodPost:
+				if r.URL.Query().Get("type") != "repo" {
+					t.Fatalf("type query = %q", r.URL.Query().Get("type"))
+				}
+				if r.Header.Get("Content-Type") != "application/json" {
+					t.Fatalf("Content-Type = %q", r.Header.Get("Content-Type"))
+				}
+				_ = json.NewEncoder(w).Encode(scanCreateResponse{TaskGroupID: "group-1", Status: "running"})
+			case http.MethodGet:
+				_ = json.NewEncoder(w).Encode(scanListResponse{Items: []scanListItem{{TaskGroupID: "group-1"}}})
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		case "/api/v1/cli/scans/result":
+			if r.URL.Query().Get("task_group_id") != "group-1" || r.URL.Query().Get("full") != "true" {
+				t.Fatalf("query = %s", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(scanResultResponse{Task: scanListItem{TaskGroupID: "group-1", Status: "success"}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newClient(server.URL, "secret")
+	created, err := client.CreateRepoScan(t.Context(), scanCreateRequest{RepoURL: "https://github.com/acme/repo"})
+	if err != nil {
+		t.Fatalf("CreateRepoScan() error = %v", err)
+	}
+	if created.TaskGroupID != "group-1" {
+		t.Fatalf("CreateRepoScan() = %+v", created)
+	}
+	list, err := client.ListScans(t.Context())
+	if err != nil {
+		t.Fatalf("ListScans() error = %v", err)
+	}
+	if len(list.Items) != 1 || list.Items[0].TaskGroupID != "group-1" {
+		t.Fatalf("ListScans() = %+v", list)
+	}
+	result, err := client.ScanResult(t.Context(), "group-1", true)
+	if err != nil {
+		t.Fatalf("ScanResult() error = %v", err)
+	}
+	if result.Task.Status != "success" {
+		t.Fatalf("ScanResult() = %+v", result)
+	}
+}
+
+func TestClientArchiveScanEndpointSendsTypeAndDisplayNames(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "monkeyscan-temp.zip")
+	if err := os.WriteFile(archive, []byte("archive-content"), 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/cli/scans" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("type") != "archive" {
+			t.Fatalf("type query = %q", r.URL.Query().Get("type"))
+		}
+		if !strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+			t.Fatalf("Content-Type = %q", r.Header.Get("Content-Type"))
+		}
+		if err := r.ParseMultipartForm(1024); err != nil {
+			t.Fatalf("ParseMultipartForm() error = %v", err)
+		}
+		if got := r.FormValue("task_name"); got != "source-dir" {
+			t.Fatalf("task_name = %q", got)
+		}
+		if got := r.FormValue("file_name"); got != "source-dir" {
+			t.Fatalf("file_name = %q", got)
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("FormFile() error = %v", err)
+		}
+		defer file.Close()
+		var uploaded bytes.Buffer
+		if _, err := uploaded.ReadFrom(file); err != nil {
+			t.Fatalf("read uploaded file: %v", err)
+		}
+		if uploaded.String() != "archive-content" {
+			t.Fatalf("uploaded file = %q", uploaded.String())
+		}
+		_ = json.NewEncoder(w).Encode(scanCreateResponse{TaskGroupID: "group-2", Status: "running"})
+	}))
+	defer server.Close()
+
+	created, err := newClient(server.URL, "secret").CreateArchiveScanWithName(t.Context(), archive, "source-dir", "source-dir")
+	if err != nil {
+		t.Fatalf("CreateArchiveScanWithName() error = %v", err)
+	}
+	if created.TaskGroupID != "group-2" {
+		t.Fatalf("CreateArchiveScanWithName() = %+v", created)
 	}
 }
 

--- a/products/monkeyscan/command_test.go
+++ b/products/monkeyscan/command_test.go
@@ -251,6 +251,46 @@ func TestClientArchiveScanEndpointSendsTypeAndDisplayNames(t *testing.T) {
 	}
 }
 
+func TestValidateArchiveFileBodySizeRejectsOver100MB(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "oversized.zip")
+	file, err := os.Create(archive)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	if err := file.Truncate(maxArchiveFileBody + 1); err != nil {
+		_ = file.Close()
+		t.Fatalf("truncate archive: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+
+	err = validateArchiveFileBodySize(archive)
+	if err == nil || !strings.Contains(err.Error(), "超过 100M 限制") {
+		t.Fatalf("validateArchiveFileBodySize() error = %v, want 100M limit", err)
+	}
+}
+
+func TestScanCommandsRejectUnexpectedArgs(t *testing.T) {
+	tests := [][]string{
+		{"scan", "./repo"},
+		{"scan", "list", "extra"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			cmd := NewCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(args)
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "unknown command") && !strings.Contains(err.Error(), "accepts 0 arg") {
+				t.Fatalf("Execute(%v) error = %v, output = %s", args, err, out.String())
+			}
+		})
+	}
+}
+
 func TestReviewStatusRecognizesSuccessRunStatus(t *testing.T) {
 	if !isTerminalReviewStatus("success", "") {
 		t.Fatal("success run status should be terminal")

--- a/products/monkeyscan/render.go
+++ b/products/monkeyscan/render.go
@@ -37,6 +37,123 @@ func printReviewSummary(cmd *cobra.Command, detail *reviewDetail, reviewPath str
 	fmt.Fprintln(cmd.OutOrStdout(), "提示: .monkeyscan 可能包含代码 diff 和修复建议，请不要提交到仓库。")
 }
 
+func printScanCreated(cmd *cobra.Command, resp *scanCreateResponse) {
+	fmt.Fprintln(cmd.OutOrStdout(), "MonkeyScan 扫描任务已创建")
+	fmt.Fprintf(cmd.OutOrStdout(), "Task Group ID: %s\n", resp.TaskGroupID)
+	fmt.Fprintf(cmd.OutOrStdout(), "状态: %s\n", resp.Status)
+	fmt.Fprintf(cmd.OutOrStdout(), "扫描对象: %s\n", scanTargetLabel(resp.ScanTarget))
+	for _, next := range resp.NextCommands {
+		fmt.Fprintf(cmd.OutOrStdout(), "后续查询: %s\n", next)
+	}
+}
+
+func printScanList(cmd *cobra.Command, resp *scanListResponse) {
+	fmt.Fprintln(cmd.OutOrStdout(), "最近 7 天全量扫描任务")
+	if len(resp.Items) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "暂无扫描任务。")
+		return
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%-36s  %-14s  %-24s  %-8s  %-20s\n", "TASK_GROUP_ID", "STATUS", "TARGET", "DEFECTS", "CREATED_AT")
+	for _, item := range resp.Items {
+		fmt.Fprintf(
+			cmd.OutOrStdout(),
+			"%-36s  %-14s  %-24s  %-8d  %-20s\n",
+			item.TaskGroupID,
+			item.Status,
+			truncate(scanTargetLabel(item.ScanTarget), 24),
+			item.DefectCount,
+			formatTime(item.CreatedAt),
+		)
+	}
+}
+
+func outputScanResult(cmd *cobra.Command, result *scanResultResponse, output string) error {
+	content := renderScanResultMarkdown(result)
+	if strings.TrimSpace(output) != "" {
+		if err := os.WriteFile(output, []byte(content), 0o600); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "扫描结果已写入: %s\n", output)
+		return nil
+	}
+	fmt.Fprint(cmd.OutOrStdout(), content)
+	return nil
+}
+
+func renderScanResultMarkdown(result *scanResultResponse) string {
+	var b strings.Builder
+	b.WriteString("# MonkeyScan 扫描结果\n\n")
+	b.WriteString("## 基础信息\n\n")
+	fmt.Fprintf(&b, "- Task Group ID: %s\n", result.Task.TaskGroupID)
+	fmt.Fprintf(&b, "- 状态: %s\n", result.Task.Status)
+	fmt.Fprintf(&b, "- 扫描对象: %s\n", scanTargetLabel(result.Task.ScanTarget))
+	fmt.Fprintf(&b, "- 创建时间: %s\n", formatTime(result.Task.CreatedAt))
+	fmt.Fprintf(&b, "- 更新时间: %s\n\n", formatTime(result.Task.UpdatedAt))
+	b.WriteString("## 统计摘要\n\n")
+	fmt.Fprintf(&b, "- 漏洞总数: %d\n", result.Total)
+	fmt.Fprintf(&b, "- Critical: %d\n", result.Severity.Critical)
+	fmt.Fprintf(&b, "- High: %d\n", result.Severity.High)
+	fmt.Fprintf(&b, "- Medium: %d\n", result.Severity.Medium)
+	fmt.Fprintf(&b, "- Low: %d\n\n", result.Severity.Low)
+	b.WriteString("## 漏洞列表\n\n")
+	if len(result.Items) == 0 {
+		b.WriteString("未发现漏洞。\n")
+		return b.String()
+	}
+	for i, item := range result.Items {
+		title := firstNonEmpty(item.DefectNameZh, item.DefectName, item.RuleName, item.ID)
+		fmt.Fprintf(&b, "### %d. %s\n\n", i+1, title)
+		fmt.Fprintf(&b, "- 严重性: %s\n", item.Severity)
+		if item.FilePath != "" {
+			fmt.Fprintf(&b, "- 位置: %s:%d\n", item.FilePath, item.Line)
+		}
+		if item.RuleName != "" {
+			fmt.Fprintf(&b, "- 规则: %s\n", item.RuleName)
+		}
+		fmt.Fprintf(&b, "- 验证状态: %d\n", item.AiVerifyStatus)
+		if !result.Full {
+			b.WriteString("\n")
+			continue
+		}
+		if text := firstNonEmpty(item.MessageZh, item.Message, item.CheckerMessage); text != "" {
+			fmt.Fprintf(&b, "\n**描述**\n\n%s\n", text)
+		}
+		if item.CodeSnippet != "" {
+			fmt.Fprintf(&b, "\n**代码片段**\n\n```text\n%s\n```\n", item.CodeSnippet)
+		}
+		if text := firstNonEmpty(item.Recommendation, item.AiSuggestion); text != "" {
+			fmt.Fprintf(&b, "\n**修复建议**\n\n%s\n", text)
+		}
+		if item.AiVerification != "" {
+			fmt.Fprintf(&b, "\n**验证/降噪结论**\n\n%s\n", item.AiVerification)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func scanTargetLabel(target scanTarget) string {
+	switch target.Type {
+	case "git":
+		if target.Ref != "" {
+			return fmt.Sprintf("%s@%s", firstNonEmpty(target.URL, target.Name), target.Ref)
+		}
+		return firstNonEmpty(target.URL, target.Name)
+	default:
+		return firstNonEmpty(target.Name, target.URL, target.Type)
+	}
+}
+
+func truncate(value string, width int) string {
+	if len(value) <= width {
+		return value
+	}
+	if width <= 3 {
+		return value[:width]
+	}
+	return value[:width-3] + "..."
+}
+
 func writeReviewMarkdown(path string, detail *reviewDetail) error {
 	var b strings.Builder
 	b.WriteString("# MonkeyScan Review 结果\n\n")

--- a/products/monkeyscan/render.go
+++ b/products/monkeyscan/render.go
@@ -95,6 +95,9 @@ func renderScanResultMarkdown(result *scanResultResponse) string {
 	fmt.Fprintf(&b, "- High: %d\n", result.Severity.High)
 	fmt.Fprintf(&b, "- Medium: %d\n", result.Severity.Medium)
 	fmt.Fprintf(&b, "- Low: %d\n\n", result.Severity.Low)
+	if result.Truncated {
+		fmt.Fprintf(&b, "> 结果数量较多，本次仅展示前 %d 条。请在 MonkeyScan 页面查看完整结果。\n\n", len(result.Items))
+	}
 	b.WriteString("## 漏洞列表\n\n")
 	if len(result.Items) == 0 {
 		b.WriteString("未发现漏洞。\n")

--- a/products/monkeyscan/scan_archive.go
+++ b/products/monkeyscan/scan_archive.go
@@ -17,6 +17,9 @@ func prepareScanArchive(opts scanOptions) (string, func(), error) {
 		if err := validateArchive(opts.File); err != nil {
 			return "", func() {}, err
 		}
+		if err := validateArchiveFileBodySize(opts.File); err != nil {
+			return "", func() {}, err
+		}
 		return opts.File, func() {}, nil
 	}
 	source := strings.TrimSpace(opts.Path)
@@ -44,6 +47,10 @@ func prepareScanArchive(opts scanOptions) (string, func(), error) {
 		return "", func() {}, err
 	}
 	if err := validateArchive(tmpPath); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	if err := validateArchiveFileBodySize(tmpPath); err != nil {
 		cleanup()
 		return "", func() {}, err
 	}
@@ -122,6 +129,17 @@ func validateArchive(filePath string) error {
 		return validateZipArchive(&reader.Reader)
 	}
 	return validateTarGzArchive(filePath)
+}
+
+func validateArchiveFileBodySize(filePath string) error {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+	if info.Size() > maxArchiveFileBody {
+		return fmt.Errorf("压缩包当前大小是 %.1f M，超过 100M 限制", float64(info.Size())/(1024*1024))
+	}
+	return nil
 }
 
 func archiveTypeFromPath(filePath string) (string, error) {

--- a/products/monkeyscan/scan_archive.go
+++ b/products/monkeyscan/scan_archive.go
@@ -1,0 +1,213 @@
+package monkeyscan
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func prepareScanArchive(opts scanOptions) (string, func(), error) {
+	if strings.TrimSpace(opts.File) != "" {
+		if err := validateArchive(opts.File); err != nil {
+			return "", func() {}, err
+		}
+		return opts.File, func() {}, nil
+	}
+	source := strings.TrimSpace(opts.Path)
+	if source == "" {
+		source = "."
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", func() {}, err
+	}
+	if !info.IsDir() {
+		return "", func() {}, fmt.Errorf("--path 必须是目录: %s", source)
+	}
+	tmp, err := os.CreateTemp("", "monkeyscan-*.zip")
+	if err != nil {
+		return "", func() {}, err
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if err := zipDirectory(source, tmpPath); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	if err := validateArchive(tmpPath); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return tmpPath, cleanup, nil
+}
+
+func zipDirectory(sourceDir, outputPath string) error {
+	out, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	zw := zip.NewWriter(out)
+	defer zw.Close()
+	root, err := filepath.Abs(sourceDir)
+	if err != nil {
+		return err
+	}
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := entry.Name()
+		if entry.IsDir() && (name == ".git" || name == ".monkeyscan") {
+			return filepath.SkipDir
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		header.Name = rel
+		header.Method = zip.Deflate
+		writer, err := zw.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(writer, in)
+		closeErr := in.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+}
+
+func validateArchive(filePath string) error {
+	archiveType, err := archiveTypeFromPath(filePath)
+	if err != nil {
+		return err
+	}
+	if archiveType == "zip" {
+		reader, err := zip.OpenReader(filePath)
+		if err != nil {
+			return fmt.Errorf("无效的 zip 文件: %w", err)
+		}
+		defer reader.Close()
+		return validateZipArchive(&reader.Reader)
+	}
+	return validateTarGzArchive(filePath)
+}
+
+func archiveTypeFromPath(filePath string) (string, error) {
+	lower := strings.ToLower(filePath)
+	switch {
+	case strings.HasSuffix(lower, ".tar.gz"), strings.HasSuffix(lower, ".tgz"):
+		return "targz", nil
+	case filepath.Ext(lower) == ".zip":
+		return "zip", nil
+	default:
+		return "", errors.New("仅支持 .zip、.tar.gz、.tgz 压缩包")
+	}
+}
+
+func validateZipArchive(reader *zip.Reader) error {
+	var total int64
+	for i, file := range reader.File {
+		if i+1 > maxArchiveEntries {
+			return fmt.Errorf("压缩包条目数量超过限制: %d > %d", i+1, maxArchiveEntries)
+		}
+		if err := validateArchiveEntry(file.Name, int64(file.UncompressedSize64), file.FileInfo().IsDir()); err != nil {
+			return err
+		}
+		if !file.FileInfo().IsDir() {
+			total += int64(file.UncompressedSize64)
+			if total > maxArchiveSize {
+				return fmt.Errorf("压缩包总解压体积超过限制: %d > %d", total, maxArchiveSize)
+			}
+		}
+	}
+	return nil
+}
+
+func validateTarGzArchive(filePath string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("无效的 gzip 文件: %w", err)
+	}
+	defer gzr.Close()
+	tr := tar.NewReader(gzr)
+	var total int64
+	count := 0
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("读取 tar 条目失败: %w", err)
+		}
+		count++
+		if count > maxArchiveEntries {
+			return fmt.Errorf("压缩包条目数量超过限制: %d > %d", count, maxArchiveEntries)
+		}
+		isDir := header.Typeflag == tar.TypeDir
+		if err := validateArchiveEntry(header.Name, header.Size, isDir); err != nil {
+			return err
+		}
+		if header.Typeflag == tar.TypeReg {
+			total += header.Size
+			if total > maxArchiveSize {
+				return fmt.Errorf("压缩包总解压体积超过限制: %d > %d", total, maxArchiveSize)
+			}
+		}
+	}
+}
+
+func validateArchiveEntry(name string, size int64, isDir bool) error {
+	clean := filepath.Clean(name)
+	if filepath.IsAbs(clean) {
+		return fmt.Errorf("不允许使用绝对路径: %s", name)
+	}
+	if strings.HasPrefix(clean, "..") || strings.Contains(clean, "../") || strings.Contains(clean, "..\\") {
+		return fmt.Errorf("检测到路径穿越攻击: %s", name)
+	}
+	depth := strings.Count(name, "/") + strings.Count(name, "\\")
+	if depth > maxArchiveDepth {
+		return fmt.Errorf("文件路径深度超过限制: %s (深度: %d > %d)", name, depth, maxArchiveDepth)
+	}
+	if !isDir && size > maxArchiveFileSize {
+		return fmt.Errorf("单个文件大小超过限制: %s (%d > %d)", name, size, maxArchiveFileSize)
+	}
+	return nil
+}

--- a/products/monkeyscan/types.go
+++ b/products/monkeyscan/types.go
@@ -124,9 +124,10 @@ type scanResultResponse struct {
 		Medium   int `json:"medium"`
 		Low      int `json:"low"`
 	} `json:"severity"`
-	Total int          `json:"total"`
-	Items []scanDefect `json:"items"`
-	Full  bool         `json:"full"`
+	Total     int          `json:"total"`
+	Items     []scanDefect `json:"items"`
+	Full      bool         `json:"full"`
+	Truncated bool         `json:"truncated"`
 }
 
 type scanDefect struct {

--- a/products/monkeyscan/types.go
+++ b/products/monkeyscan/types.go
@@ -9,6 +9,7 @@ const (
 	envURLName         = "MONKEYSCAN_URL"
 	reviewsDir         = ".monkeyscan/reviews"
 	maxReviewBodySize  = 5 * 1024 * 1024
+	maxArchiveFileBody = 100 * 1024 * 1024
 	maxArchiveEntries  = 50000
 	maxArchiveDepth    = 100
 	maxArchiveSize     = 1024 * 1024 * 1024

--- a/products/monkeyscan/types.go
+++ b/products/monkeyscan/types.go
@@ -3,12 +3,16 @@ package monkeyscan
 import "time"
 
 const (
-	productName       = "monkeyscan"
-	defaultURL        = "https://monkeyscan-ai.com"
-	envAPIKeyName     = "MONKEYSCAN_API_KEY"
-	envURLName        = "MONKEYSCAN_URL"
-	reviewsDir        = ".monkeyscan/reviews"
-	maxReviewBodySize = 5 * 1024 * 1024
+	productName        = "monkeyscan"
+	defaultURL         = "https://monkeyscan-ai.com"
+	envAPIKeyName      = "MONKEYSCAN_API_KEY"
+	envURLName         = "MONKEYSCAN_URL"
+	reviewsDir         = ".monkeyscan/reviews"
+	maxReviewBodySize  = 5 * 1024 * 1024
+	maxArchiveEntries  = 50000
+	maxArchiveDepth    = 100
+	maxArchiveSize     = 1024 * 1024 * 1024
+	maxArchiveFileSize = 1024 * 1024 * 1024
 )
 
 type Config struct {
@@ -69,6 +73,79 @@ type diffReviewResponse struct {
 	RunID       string `json:"run_id"`
 	TaskGroupID string `json:"task_group_id"`
 	Status      string `json:"status"`
+}
+
+type scanCreateRequest struct {
+	RepoURL  string `json:"repo_url"`
+	Branch   string `json:"branch,omitempty"`
+	TaskName string `json:"task_name,omitempty"`
+}
+
+type scanCreateResponse struct {
+	TaskGroupID  string     `json:"task_group_id"`
+	Status       string     `json:"status"`
+	ScanTarget   scanTarget `json:"scan_target"`
+	NextCommands []string   `json:"next_commands"`
+}
+
+type scanTarget struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+	URL  string `json:"url,omitempty"`
+	Ref  string `json:"ref,omitempty"`
+}
+
+type scanListResponse struct {
+	Items    []scanListItem `json:"items"`
+	Total    int            `json:"total"`
+	Page     int            `json:"page"`
+	PageSize int            `json:"page_size"`
+	HasNext  bool           `json:"has_next"`
+}
+
+type scanListItem struct {
+	TaskGroupID           string     `json:"task_group_id"`
+	Status                string     `json:"status"`
+	ScanTarget            scanTarget `json:"scan_target"`
+	DefectCount           int        `json:"defect_count"`
+	CriticalSeverityCount int        `json:"critical_severity_count"`
+	HighSeverityCount     int        `json:"high_severity_count"`
+	MediumSeverityCount   int        `json:"medium_severity_count"`
+	CreatedAt             time.Time  `json:"created_at"`
+	UpdatedAt             time.Time  `json:"updated_at"`
+}
+
+type scanResultResponse struct {
+	Task     scanListItem `json:"task"`
+	Severity struct {
+		Critical int `json:"critical"`
+		High     int `json:"high"`
+		Medium   int `json:"medium"`
+		Low      int `json:"low"`
+	} `json:"severity"`
+	Total int          `json:"total"`
+	Items []scanDefect `json:"items"`
+	Full  bool         `json:"full"`
+}
+
+type scanDefect struct {
+	ID             string `json:"id"`
+	RuleName       string `json:"ruleName"`
+	DefectName     string `json:"defectName"`
+	DefectNameZh   string `json:"defectNameZh,omitempty"`
+	Severity       string `json:"severity"`
+	FilePath       string `json:"filepath,omitempty"`
+	Line           int    `json:"line,omitempty"`
+	Message        string `json:"message,omitempty"`
+	MessageZh      string `json:"messageZh,omitempty"`
+	CheckerMessage string `json:"checkerMessage,omitempty"`
+	AiVerification string `json:"aiVerification,omitempty"`
+	AiSuggestion   string `json:"aiSuggestion,omitempty"`
+	AiVerifyStatus int    `json:"aiVerifyStatus"`
+	Pipeline       int    `json:"pipeline"`
+	Confidence     string `json:"confidence,omitempty"`
+	Recommendation string `json:"recommendation,omitempty"`
+	CodeSnippet    string `json:"codeSnippet,omitempty"`
 }
 
 type reviewDetail struct {
@@ -149,6 +226,17 @@ type reviewScope struct {
 	All        bool
 	Base       string
 	BaseCommit string
+}
+
+type scanOptions struct {
+	Path        string
+	File        string
+	Repo        string
+	TaskGroupID string
+	Branch      string
+	Wait        bool
+	Full        bool
+	Output      string
 }
 
 type diffSnapshot struct {


### PR DESCRIPTION
## Summary
- add monkeyscan scan command for local archive/path and GitHub repo full scan
- add scan list and scan result commands
- call ScanMatrix CLI scan APIs with explicit type query
- stream archive upload and validate local archive safety

## Validation
- go test ./products/monkeyscan
- go run . monkeyscan --help
- go run . monkeyscan scan --help
- go run . monkeyscan scan list --help
- go run . monkeyscan scan result --help

Draft until the paired ScanMatrix MR is reviewed.