### PR TITLE
use global config path

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -96,7 +96,7 @@ The root command handles configuration loading, product command registration, an
 
 ## Configuration
 
-Put product connection settings in `./config.yaml`:
+Prefer putting product connection settings in `~/.chaitin-cli/config.yaml`. If `./config.yaml` exists in the current directory and has a chaitin-cli product name at the top level, the CLI reads that local config first to keep existing workflows compatible:
 
 ```yaml
 cloudwalker:
@@ -198,14 +198,16 @@ XRAY_URL=https://xray.example.com/api/v2
 XRAY_API_KEY=YOUR_API_KEY
 ```
 
-Priority is `flags > environment/.env > config.yaml`.
+Priority is `flags > environment/.env > recognized ./config.yaml > ~/.chaitin-cli/config.yaml`. If `./config.yaml` does not contain a chaitin-cli product name, it is treated as another project's config and ignored. When a local config is recognized, global config is not merged.
 
-Use root-level `-c` or `--config` to load a different config file. This is useful when you switch between multiple product instances, for example multiple SafeLine environments:
+Use root-level `-c` or `--config` to load a different config file. This is useful when you switch between multiple product instances or temporarily use a project-local config file, for example multiple SafeLine environments:
 
 ```bash
 chaitin-cli -c ./configs/safeline-prod.yaml safeline stats overview
 chaitin-cli -c ./configs/safeline-staging.yaml safeline stats overview
 ```
+
+Commands that create or update config use the same path selection by default: if a recognized `./config.yaml` exists in the current directory, they write to it first; otherwise they write to `~/.chaitin-cli/config.yaml`. When `-c` / `--config` is set explicitly, they write only to the specified file.
 
 Use root-level `--dry-run` for commands that support dry-run:
 
@@ -363,7 +365,7 @@ Check whether the install directory is in `PATH`. The macOS / Linux installer pr
 
 **Where is configuration loaded from?**
 
-Priority is `flags > environment/.env > config.yaml`. Use root-level `-c` or `--config` to load a different config file.
+By default, configuration is loaded first from a current-directory `./config.yaml` recognized as chaitin-cli config, otherwise from `~/.chaitin-cli/config.yaml`. Priority is `flags > environment/.env > recognized ./config.yaml > ~/.chaitin-cli/config.yaml`. Use root-level `-c` or `--config` to load a different config file.
 
 **What should I do if a self-signed certificate causes connection failures?**
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ npx skills add chaitin/chaitin-cli
 
 ## 配置
 
-将各产品的连接信息写入 `./config.yaml`：
+推荐将各产品的连接信息写入 `~/.chaitin-cli/config.yaml`。如果当前目录存在 `./config.yaml`，且顶层包含 chaitin-cli 产品名，CLI 会优先读取这个本地配置，以兼容既有使用流程：
 
 ```yaml
 cloudAtlas:
@@ -287,14 +287,16 @@ XRAY_URL=https://xray.example.com/api/v2
 XRAY_API_KEY=YOUR_API_KEY
 ```
 
-优先级为 `flags > environment/.env > config.yaml`
+优先级为 `flags > environment/.env > 识别后的 ./config.yaml > ~/.chaitin-cli/config.yaml`。如果 `./config.yaml` 不包含 chaitin-cli 产品名，会被视为其他项目配置并忽略。识别到本地配置时，不会再合并全局配置。
 
-可以通过根命令的 `-c` 或 `--config` 指定其他配置文件。这在切换多个产品实例时很有用，例如多个 SafeLine 环境：
+可以通过根命令的 `-c` 或 `--config` 指定其他配置文件。这在切换多个产品实例或临时使用项目内配置时很有用，例如多个 SafeLine 环境：
 
 ```bash
 chaitin-cli -c ./configs/safeline-prod.yaml safeline stats overview
 chaitin-cli -c ./configs/safeline-staging.yaml safeline stats overview
 ```
+
+会创建或更新配置的命令默认遵循同样的路径选择：如果当前目录存在可识别的 `./config.yaml`，优先写入本地文件；否则写入 `~/.chaitin-cli/config.yaml`。显式使用 `-c` / `--config` 时，只写入指定文件。
 
 支持 dry-run 的命令可以使用根级别的 `--dry-run`：
 
@@ -433,7 +435,7 @@ task package GOOS=linux GOARCH=amd64
 
 **配置从哪里读取？**
 
-优先级为 `flags > environment/.env > config.yaml`。根命令的 `-c` / `--config` 可以指定其他配置文件。
+默认优先读取当前目录中识别为 chaitin-cli 配置的 `./config.yaml`，否则读取 `~/.chaitin-cli/config.yaml`。优先级为 `flags > environment/.env > 识别后的 ./config.yaml > ~/.chaitin-cli/config.yaml`。根命令的 `-c` / `--config` 可以指定其他配置文件。
 
 **自签名证书连接失败怎么办？**
 

--- a/config/write.go
+++ b/config/write.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -10,7 +11,7 @@ import (
 func SetProduct(path, name string, value any) error {
 	cfg, err := Load(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w; use -c/--config to specify a writable config file", err)
 	}
 
 	var node yaml.Node
@@ -24,8 +25,14 @@ func SetProduct(path, name string, value any) error {
 		return fmt.Errorf("marshal config file %s: %w", path, err)
 	}
 
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("create config dir %s: %w; use -c/--config to specify a writable config file", dir, err)
+		}
+	}
+
 	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return fmt.Errorf("write config file %s: %w", path, err)
+		return fmt.Errorf("write config file %s: %w; use -c/--config to specify a writable config file", path, err)
 	}
 
 	return nil

--- a/config/write_test.go
+++ b/config/write_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -38,5 +40,87 @@ func TestSetProduct(t *testing.T) {
 
 	if got.URL != "https://example.com" || got.APIKey != "Serval token" || got.CompanyID != "corp-1" {
 		t.Fatalf("unexpected config: %+v", got)
+	}
+}
+
+func TestSetProductCreatesParentDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".chaitin-cli", "config.yaml")
+
+	if err := SetProduct(path, "ddr", struct {
+		URL string `yaml:"url"`
+	}{
+		URL: "https://example.com",
+	}); err != nil {
+		t.Fatalf("SetProduct() error = %v", err)
+	}
+
+	if _, err := Load(path); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+}
+
+func TestSetProductPreservesOtherProducts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("cosmos:\n  url: https://cosmos.example\n  api_key: cosmos-token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := SetProduct(path, "ddr", struct {
+		URL    string `yaml:"url"`
+		APIKey string `yaml:"api_key"`
+	}{
+		URL:    "https://ddr.example.com",
+		APIKey: "ddr-token",
+	}); err != nil {
+		t.Fatalf("SetProduct() error = %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	var cosmos struct {
+		URL    string `yaml:"url"`
+		APIKey string `yaml:"api_key"`
+	}
+	cosmosNode := cfg["cosmos"]
+	if err := cosmosNode.Decode(&cosmos); err != nil {
+		t.Fatalf("Decode(cosmos) error = %v", err)
+	}
+	if cosmos.URL != "https://cosmos.example" || cosmos.APIKey != "cosmos-token" {
+		t.Fatalf("cosmos config was not preserved: %+v", cosmos)
+	}
+
+	var ddr struct {
+		URL    string `yaml:"url"`
+		APIKey string `yaml:"api_key"`
+	}
+	ddrNode := cfg["ddr"]
+	if err := ddrNode.Decode(&ddr); err != nil {
+		t.Fatalf("Decode(ddr) error = %v", err)
+	}
+	if ddr.URL != "https://ddr.example.com" || ddr.APIKey != "ddr-token" {
+		t.Fatalf("ddr config was not written: %+v", ddr)
+	}
+}
+
+func TestSetProductWriteErrorMentionsConfigFlag(t *testing.T) {
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(parent, []byte("file"), 0o600); err != nil {
+		t.Fatalf("WriteFile(parent) error = %v", err)
+	}
+
+	err := SetProduct(filepath.Join(parent, "config.yaml"), "monkeyscan", struct {
+		URL string `yaml:"url"`
+	}{
+		URL: "https://example.com",
+	})
+	if err == nil {
+		t.Fatal("SetProduct() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "-c/--config") {
+		t.Fatalf("SetProduct() error = %q, want -c/--config hint", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -29,13 +29,17 @@ import (
 type app struct {
 	root             *cobra.Command
 	aliasSubcommands map[string]struct{}
+	productNames     map[string]struct{}
 	config           config.Raw
 	configPath       string
 	configLoaded     bool
 	dryRun           bool
 }
 
-const defaultConfigPath = "config.yaml"
+const (
+	defaultConfigDir  = ".chaitin-cli"
+	defaultConfigFile = "config.yaml"
+)
 
 func newApp() (*app, error) {
 	root := &cobra.Command{
@@ -48,10 +52,11 @@ func newApp() (*app, error) {
 	a := &app{
 		root:             root,
 		aliasSubcommands: make(map[string]struct{}),
-		configPath:       defaultConfigPathFromCWD(),
+		productNames:     make(map[string]struct{}),
+		configPath:       defaultConfigPath(),
 	}
 
-	root.PersistentFlags().StringVarP(&a.configPath, "config", "c", a.configPath, "Config file path")
+	root.PersistentFlags().StringVarP(&a.configPath, "config", "c", a.configPath, "Config file path; when unset, CLI tries recognized ./config.yaml before ~/.chaitin-cli/config.yaml")
 	root.PersistentFlags().BoolVar(&a.dryRun, "dry-run", false, "Do not send requests; commands that support dry-run print a request summary")
 
 	a.registerProductCommand(chaitin.NewCommand())
@@ -110,6 +115,7 @@ func (a *app) registerProductCommand(cmd *cobra.Command) {
 
 	a.wrapProductCommand(cmd)
 	a.aliasSubcommands[cmd.Name()] = struct{}{}
+	a.productNames[cmd.Name()] = struct{}{}
 	a.root.AddCommand(cmd)
 }
 
@@ -138,11 +144,11 @@ func (a *app) wrapProductCommand(cmd *cobra.Command) {
 		case "codeinsight":
 			codeinsight.ApplyRuntimeConfig(command, a.config, a.dryRun)
 		case "ddr":
-			ddr.ApplyRuntimeConfig(command, a.config, a.configPath, a.dryRun)
+			ddr.ApplyRuntimeConfig(command, a.config, a.writeConfigPath(), a.dryRun)
 		case "dsensor":
 			dsensor.ApplyRuntimeConfig(command, a.config, a.dryRun)
 		case "monkeyscan":
-			monkeyscan.ApplyRuntimeConfig(command, a.config, a.configPath, a.dryRun)
+			monkeyscan.ApplyRuntimeConfig(command, a.config, a.writeConfigPath(), a.dryRun)
 		case "tanswer":
 			tanswer.ApplyRuntimeConfig(command, a.config)
 		case "veinmind":
@@ -175,7 +181,7 @@ func (a *app) ensureRuntimeConfigLoaded() error {
 		return err
 	}
 
-	cfg, err := loadConfigFile(a.configPath)
+	cfg, err := a.loadRuntimeConfig()
 	if err != nil {
 		return err
 	}
@@ -199,8 +205,68 @@ func loadConfigFile(path string) (config.Raw, error) {
 	return config.Load(path)
 }
 
-func defaultConfigPathFromCWD() string {
-	return filepath.Join(".", defaultConfigPath)
+func (a *app) loadRuntimeConfig() (config.Raw, error) {
+	if a.configFlagChanged() {
+		return loadConfigFile(a.configPath)
+	}
+
+	localCfg, localRecognized, err := a.loadLocalConfigIfRecognized()
+	if err == nil && localRecognized {
+		return localCfg, nil
+	}
+
+	globalCfg, err := loadConfigFile(defaultConfigPath())
+	if err != nil {
+		return nil, err
+	}
+	return globalCfg, nil
+}
+
+func (a *app) writeConfigPath() string {
+	if a.configFlagChanged() {
+		return a.configPath
+	}
+	if _, ok, err := a.loadLocalConfigIfRecognized(); err == nil && ok {
+		return localConfigPath()
+	}
+	return defaultConfigPath()
+}
+
+func (a *app) loadLocalConfigIfRecognized() (config.Raw, bool, error) {
+	localCfg, err := loadConfigFile(localConfigPath())
+	if err != nil {
+		return nil, false, err
+	}
+	return localCfg, looksLikeCLIConfig(localCfg, a.productNames), nil
+}
+
+func (a *app) configFlagChanged() bool {
+	if a.root == nil {
+		return a.configPath != "" && a.configPath != defaultConfigPath()
+	}
+	flag := a.root.PersistentFlags().Lookup("config")
+	return flag != nil && flag.Changed
+}
+
+func looksLikeCLIConfig(cfg config.Raw, productNames map[string]struct{}) bool {
+	for name := range cfg {
+		if _, ok := productNames[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func localConfigPath() string {
+	return filepath.Join(".", defaultConfigFile)
+}
+
+func defaultConfigPath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		return localConfigPath()
+	}
+	return filepath.Join(homeDir, defaultConfigDir, defaultConfigFile)
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,17 @@ import (
 )
 
 func TestNewAppUsesDefaultConfigPath(t *testing.T) {
+	homeDir := t.TempDir()
+	setTestHome(t, homeDir)
+
 	app, err := newApp()
 	if err != nil {
 		t.Fatalf("newApp() error = %v", err)
 	}
 
-	if app.configPath != defaultConfigPathFromCWD() {
-		t.Fatalf("app.configPath = %q, want %q", app.configPath, defaultConfigPathFromCWD())
+	want := filepath.Join(homeDir, defaultConfigDir, defaultConfigFile)
+	if app.configPath != want {
+		t.Fatalf("app.configPath = %q, want %q", app.configPath, want)
 	}
 }
 
@@ -144,4 +148,186 @@ func TestEnsureRuntimeConfigLoadedWithMissingConfigFile(t *testing.T) {
 	if len(app.config) != 0 {
 		t.Fatalf("len(config) = %d, want 0", len(app.config))
 	}
+}
+
+func TestRuntimeConfigLoadsRecognizedLocalBeforeGlobal(t *testing.T) {
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	setTestHome(t, homeDir)
+	withWorkingDir(t, workDir)
+
+	globalPath := filepath.Join(homeDir, defaultConfigDir, defaultConfigFile)
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(globalPath, []byte("monkeyscan:\n  url: https://global.example\n  api_key: global-key\ncosmos:\n  url: https://cosmos.example\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(global) error = %v", err)
+	}
+	if err := os.WriteFile(localConfigPath(), []byte("monkeyscan:\n  url: https://local.example\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(local) error = %v", err)
+	}
+
+	app, err := newApp()
+	if err != nil {
+		t.Fatalf("newApp() error = %v", err)
+	}
+	if err := app.ensureRuntimeConfigLoaded(); err != nil {
+		t.Fatalf("ensureRuntimeConfigLoaded() error = %v", err)
+	}
+
+	var monkeyscanCfg struct {
+		URL    string `yaml:"url"`
+		APIKey string `yaml:"api_key"`
+	}
+	monkeyscanNode := app.config["monkeyscan"]
+	if err := monkeyscanNode.Decode(&monkeyscanCfg); err != nil {
+		t.Fatalf("Decode(monkeyscan) error = %v", err)
+	}
+	if monkeyscanCfg.URL != "https://local.example" || monkeyscanCfg.APIKey != "" {
+		t.Fatalf("monkeyscan config = %+v, want local config only", monkeyscanCfg)
+	}
+	if _, ok := app.config["cosmos"]; ok {
+		t.Fatal("global cosmos section should not be loaded when local config is recognized")
+	}
+}
+
+func TestRuntimeConfigIgnoresUnrecognizedLocalConfig(t *testing.T) {
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	setTestHome(t, homeDir)
+	withWorkingDir(t, workDir)
+
+	globalPath := filepath.Join(homeDir, defaultConfigDir, defaultConfigFile)
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(globalPath, []byte("monkeyscan:\n  url: https://global.example\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(global) error = %v", err)
+	}
+	if err := os.WriteFile(localConfigPath(), []byte("database:\n  host: localhost\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(local) error = %v", err)
+	}
+
+	app, err := newApp()
+	if err != nil {
+		t.Fatalf("newApp() error = %v", err)
+	}
+	if err := app.ensureRuntimeConfigLoaded(); err != nil {
+		t.Fatalf("ensureRuntimeConfigLoaded() error = %v", err)
+	}
+
+	if _, ok := app.config["database"]; ok {
+		t.Fatal("unrecognized local config section should be ignored")
+	}
+	var monkeyscanCfg struct {
+		URL string `yaml:"url"`
+	}
+	monkeyscanNode := app.config["monkeyscan"]
+	if err := monkeyscanNode.Decode(&monkeyscanCfg); err != nil {
+		t.Fatalf("Decode(monkeyscan) error = %v", err)
+	}
+	if monkeyscanCfg.URL != "https://global.example" {
+		t.Fatalf("monkeyscan url = %q, want global", monkeyscanCfg.URL)
+	}
+}
+
+func TestRuntimeConfigFallsBackToGlobalWhenLocalConfigParseFails(t *testing.T) {
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	setTestHome(t, homeDir)
+	withWorkingDir(t, workDir)
+
+	globalPath := filepath.Join(homeDir, defaultConfigDir, defaultConfigFile)
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(globalPath, []byte("monkeyscan:\n  url: https://global.example\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(global) error = %v", err)
+	}
+	if err := os.WriteFile(localConfigPath(), []byte("monkeyscan:\n  url: [broken\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(local) error = %v", err)
+	}
+
+	app, err := newApp()
+	if err != nil {
+		t.Fatalf("newApp() error = %v", err)
+	}
+	if err := app.ensureRuntimeConfigLoaded(); err != nil {
+		t.Fatalf("ensureRuntimeConfigLoaded() error = %v", err)
+	}
+
+	var monkeyscanCfg struct {
+		URL string `yaml:"url"`
+	}
+	monkeyscanNode := app.config["monkeyscan"]
+	if err := monkeyscanNode.Decode(&monkeyscanCfg); err != nil {
+		t.Fatalf("Decode(monkeyscan) error = %v", err)
+	}
+	if monkeyscanCfg.URL != "https://global.example" {
+		t.Fatalf("monkeyscan url = %q, want global", monkeyscanCfg.URL)
+	}
+}
+
+func TestWriteConfigPathUsesRecognizedLocalConfig(t *testing.T) {
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	setTestHome(t, homeDir)
+	withWorkingDir(t, workDir)
+
+	if err := os.WriteFile(localConfigPath(), []byte("monkeyscan:\n  url: https://local.example\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(local) error = %v", err)
+	}
+	app, err := newApp()
+	if err != nil {
+		t.Fatalf("newApp() error = %v", err)
+	}
+	if got := app.writeConfigPath(); got != localConfigPath() {
+		t.Fatalf("writeConfigPath() = %q, want %q", got, localConfigPath())
+	}
+}
+
+func TestWriteConfigPathUsesGlobalWhenLocalMissingOrUnrecognized(t *testing.T) {
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	setTestHome(t, homeDir)
+	withWorkingDir(t, workDir)
+
+	app, err := newApp()
+	if err != nil {
+		t.Fatalf("newApp() error = %v", err)
+	}
+	if got := app.writeConfigPath(); got != defaultConfigPath() {
+		t.Fatalf("writeConfigPath() without local = %q, want %q", got, defaultConfigPath())
+	}
+
+	if err := os.WriteFile(localConfigPath(), []byte("database:\n  host: localhost\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(local) error = %v", err)
+	}
+	if got := app.writeConfigPath(); got != defaultConfigPath() {
+		t.Fatalf("writeConfigPath() with unrecognized local = %q, want %q", got, defaultConfigPath())
+	}
+}
+
+func withWorkingDir(t *testing.T, dir string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("Chdir() cleanup error = %v", err)
+		}
+	})
+}
+
+func setTestHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
 }

--- a/products/codeforce/types.go
+++ b/products/codeforce/types.go
@@ -88,10 +88,10 @@ func (c Config) normalized() Config {
 
 func (c Config) validate() error {
 	if strings.TrimSpace(c.URL) == "" {
-		return fmt.Errorf("codeforce url is not configured; set --url, CODEFORCE_URL, or config.yaml codeforce.url")
+		return fmt.Errorf("codeforce url is not configured; set --url, CODEFORCE_URL, or config file codeforce.url")
 	}
 	if strings.TrimSpace(c.AccessToken) == "" {
-		return fmt.Errorf("codeforce access token is not configured; set --access-token/--api-key, CODEFORCE_ACCESS_TOKEN/CODEFORCE_API_KEY, or config.yaml codeforce.access_token")
+		return fmt.Errorf("codeforce access token is not configured; set --access-token/--api-key, CODEFORCE_ACCESS_TOKEN/CODEFORCE_API_KEY, or config file codeforce.access_token")
 	}
 	switch c.AccountType {
 	case accountTypeAdmin, accountTypeUser, accountTypeOpenAPI:

--- a/products/codeinsight/types.go
+++ b/products/codeinsight/types.go
@@ -105,10 +105,10 @@ func (c Config) normalized() Config {
 
 func (c Config) validate() error {
 	if strings.TrimSpace(c.URL) == "" {
-		return fmt.Errorf("codeinsight url is not configured; set --url, CODEINSIGHT_URL, or config.yaml codeinsight.url")
+		return fmt.Errorf("codeinsight url is not configured; set --url, CODEINSIGHT_URL, or config file codeinsight.url")
 	}
 	if strings.TrimSpace(c.AccessToken) == "" {
-		return fmt.Errorf("codeinsight access token is not configured; set --access-token, CODEINSIGHT_TOKEN/CODEINSIGHT_ACCESS_TOKEN, or config.yaml codeinsight.access_token")
+		return fmt.Errorf("codeinsight access token is not configured; set --access-token, CODEINSIGHT_TOKEN/CODEINSIGHT_ACCESS_TOKEN, or config file codeinsight.access_token")
 	}
 	return nil
 }

--- a/products/cosmos/README.md
+++ b/products/cosmos/README.md
@@ -6,7 +6,7 @@ Cosmos（万象/AISOC）命令行工具，通过 JSON-RPC 2.0 调用万象后端
 
 ## 配置
 
-在当前工作目录的 `config.yaml` 中配置：
+推荐在 `~/.chaitin-cli/config.yaml` 中配置；当前目录下可识别的 `./config.yaml` 会被优先读取：
 
 ```yaml
 cosmos:
@@ -27,7 +27,7 @@ export COSMOS_API_KEY=YOUR_JWT_TOKEN
 chaitin-cli cosmos --url https://cosmos.example.com --api-key YOUR_JWT_TOKEN asset search-host-asset --count 20 --offset 0
 ```
 
-优先级为 `flags > environment/.env > config.yaml`。
+优先级为 `flags > environment/.env > 识别后的 ./config.yaml > ~/.chaitin-cli/config.yaml`。
 
 注意事项：
 

--- a/products/ddr/get_api_token.go
+++ b/products/ddr/get_api_token.go
@@ -56,7 +56,7 @@ func newGetAPITokenCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "get-api-token",
-		Short: "Create a Serval API token from a JWT token and persist it to config.yaml",
+		Short: "Create a Serval API token from a JWT token and persist it to a config file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runtimeConfigPath == "" {
 				return fmt.Errorf("config path is empty")

--- a/products/dsensor/README.md
+++ b/products/dsensor/README.md
@@ -10,7 +10,7 @@ chaitin-cli dsensor --help
 
 ## Configuration
 
-Use `config.yaml`:
+Use `~/.chaitin-cli/config.yaml`, or a recognized local `./config.yaml`:
 
 ```yaml
 dsensor:

--- a/products/safeline-ce/command.go
+++ b/products/safeline-ce/command.go
@@ -32,7 +32,7 @@ func NewCommand() *cobra.Command {
 		Long: `SafeLine CE CLI - SafeLine 社区版命令行管理工具
 
 快速入门:
-  # 1. 创建配置文件 config.yaml
+  # 1. 创建配置文件 ~/.chaitin-cli/config.yaml
   safeline-ce:
     url: https://your-server:9443
     api_key: your-api-key

--- a/products/tanswer/README.md
+++ b/products/tanswer/README.md
@@ -4,7 +4,7 @@
 
 ## 配置
 
-在当前工作目录的 `config.yaml` 中配置：
+推荐在 `~/.chaitin-cli/config.yaml` 中配置；当前目录下可识别的 `./config.yaml` 会被优先读取：
 
 ```yaml
 tanswer:


### PR DESCRIPTION
## Summary
- prefer recognized ./config.yaml for existing local workflows, otherwise read ~/.chaitin-cli/config.yaml
- write generated config to recognized ./config.yaml when present, otherwise ~/.chaitin-cli/config.yaml
- create config parent directories and update docs/tests for config path behavior

## Tests
- go test ./...
