### PR TITLE
add cosmos alarm ai field updates

### DIFF
--- a/products/cosmos/README.md
+++ b/products/cosmos/README.md
@@ -134,6 +134,24 @@ chaitin-cli cosmos alarm get-alarm-list \
 chaitin-cli cosmos alarm get-alarm-info --id ALARM_ID --created_at CREATED_AT_MS --raw
 ```
 
+预览写回告警 AI 研判与处置字段。专用后端接口为 `AlarmService.UpdateAiFieldsContent`，参数必须包装在 `ai_fields` 中；去掉根级 `--dry-run` 后才会真实写入：
+
+```bash
+chaitin-cli --dry-run cosmos alarm update-ai-fields-content \
+  --ai_fields.alarm_id ALARM_ID \
+  --ai_fields.analysis_report '# AI研判报告' \
+  --ai_fields.confidence_score 85 \
+  --ai_fields.ai_analysis 1 \
+  --ai_fields.ai_judgment_result '误报' \
+  --ai_fields.ai_judgment_level 1 \
+  --ai_fields.ai_event_nature '业务测试' \
+  --ai_fields.disposal_report '# AI处置报告' \
+  --ai_fields.ai_disposal 1 \
+  --raw
+```
+
+字段映射为：`analysis_report -> ai_analysis_result`、`confidence_score -> ai_confidence_score`、`disposal_report -> ai_disposal_result`；其余 AI 参数与告警返回字段同名。`ai_fields.created_at` 是可选 RFC3339 分区键，只能使用告警详情返回的真实创建时间转换得到；不确定时不要传。
+
 查询安全日志：
 
 ```bash

--- a/products/cosmos/api_specs_test.go
+++ b/products/cosmos/api_specs_test.go
@@ -10,12 +10,13 @@ import (
 )
 
 // TestAlarmJSON_Structure 验证 alarm.json 的结构完整性：
-// - 6 个 API 全部存在
+// - 7 个 API 全部存在
 // - UpdateAlarmInfo 关键字段为必填
 // - UpdateAlarmMoreInfo 包含新增的 5 个嵌套对象
+// - UpdateAiFieldsContent 使用 ai_fields 包装专用 AI 字段
 // - MultiJudgeAlert.remark 为必填
 func TestAlarmJSON_Structure(t *testing.T) {
-	ops := loadAPIOperations(t, "alarm.json", 6)
+	ops := loadAPIOperations(t, "alarm.json", 7)
 	byName := mapByName(ops)
 
 	// 1) GetAlarmList 存在且 queryType 注解正确
@@ -143,7 +144,111 @@ func TestAlarmJSON_Structure(t *testing.T) {
 		}
 	})
 
-	t.Log("All 6 APIs validated successfully")
+	// 8) AI 字段只能通过专用接口写回，且必须包装在 ai_fields 中。
+	t.Run("UpdateAiFieldsContent", func(t *testing.T) {
+		op, ok := byName["AlarmService.UpdateAiFieldsContent"]
+		if !ok {
+			t.Fatal("missing UpdateAiFieldsContent")
+		}
+
+		if field, ok := op.Args["ai_fields.alarm_id"]; !ok {
+			t.Fatal("missing ai_fields.alarm_id")
+		} else if field.Optional {
+			t.Error("ai_fields.alarm_id should be required")
+		}
+
+		for _, name := range []string{
+			"ai_fields.analysis_report",
+			"ai_fields.confidence_score",
+			"ai_fields.ai_analysis",
+			"ai_fields.ai_judgment_result",
+			"ai_fields.ai_judgment_level",
+			"ai_fields.ai_event_nature",
+			"ai_fields.disposal_report",
+			"ai_fields.ai_disposal",
+			"ai_fields.created_at",
+		} {
+			field, ok := op.Args[name]
+			if !ok {
+				t.Errorf("missing %s", name)
+				continue
+			}
+			if !field.Optional {
+				t.Errorf("%s should be optional", name)
+			}
+		}
+		assertOperationRegistered(t, op)
+	})
+
+	t.Log("All 7 APIs validated successfully")
+}
+
+func TestUpdateAiFieldsContentDryRun(t *testing.T) {
+	oldServerURL := serverURL
+	oldAPIToken := apiToken
+	oldDryRun := dryRun
+	t.Cleanup(func() {
+		serverURL = oldServerURL
+		apiToken = oldAPIToken
+		dryRun = oldDryRun
+	})
+
+	serverURL = "https://cosmos.example.com"
+	apiToken = "test-token"
+	dryRun = true
+
+	cmd := NewCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{
+		"alarm", "update-ai-fields-content",
+		"--ai_fields.alarm_id", "alarm-1",
+		"--ai_fields.analysis_report", "analysis",
+		"--ai_fields.confidence_score", "85",
+		"--ai_fields.ai_analysis", "1",
+		"--ai_fields.ai_judgment_result", "误报",
+		"--ai_fields.ai_judgment_level", "1",
+		"--ai_fields.ai_event_nature", "业务测试",
+		"--ai_fields.disposal_report", "disposal",
+		"--ai_fields.ai_disposal", "1",
+		"--raw",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute update-ai-fields-content: %v", err)
+	}
+
+	var summary dryRunRequestSummary
+	if err := json.Unmarshal(out.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal dry-run output: %v\n%s", err, out.String())
+	}
+	if summary.Body.Method != "AlarmService.UpdateAiFieldsContent" {
+		t.Fatalf("method = %q, want AlarmService.UpdateAiFieldsContent", summary.Body.Method)
+	}
+
+	params, ok := summary.Body.Params.(map[string]interface{})
+	if !ok {
+		t.Fatalf("params type = %T, want map[string]interface{}", summary.Body.Params)
+	}
+	aiFields, ok := params["ai_fields"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("ai_fields type = %T, want map[string]interface{}", params["ai_fields"])
+	}
+	for name, want := range map[string]interface{}{
+		"alarm_id":           "alarm-1",
+		"analysis_report":    "analysis",
+		"confidence_score":   float64(85),
+		"ai_analysis":        float64(1),
+		"ai_judgment_result": "误报",
+		"ai_judgment_level":  "1",
+		"ai_event_nature":    "业务测试",
+		"disposal_report":    "disposal",
+		"ai_disposal":        float64(1),
+	} {
+		if got := aiFields[name]; got != want {
+			t.Errorf("ai_fields.%s = %#v, want %#v", name, got, want)
+		}
+	}
 }
 
 func TestAssetJSONStructure(t *testing.T) {

--- a/products/cosmos/apis/alarm.json
+++ b/products/cosmos/apis/alarm.json
@@ -682,6 +682,63 @@
     "reply": {}
   },
   {
+    "name": "AlarmService.UpdateAiFieldsContent",
+    "comment": "更新告警 AI 研判与处置字段",
+    "args": {
+      "ai_fields.alarm_id": {
+        "type": "string",
+        "optional": false,
+        "comment": "告警ID（必填）"
+      },
+      "ai_fields.analysis_report": {
+        "type": "string",
+        "optional": true,
+        "comment": "AI研判报告，写入告警字段 ai_analysis_result"
+      },
+      "ai_fields.confidence_score": {
+        "type": "integer",
+        "optional": true,
+        "comment": "AI置信度，写入告警字段 ai_confidence_score"
+      },
+      "ai_fields.ai_analysis": {
+        "type": "integer",
+        "optional": true,
+        "comment": "AI是否研判: 0否 1是"
+      },
+      "ai_fields.ai_judgment_result": {
+        "type": "string",
+        "optional": true,
+        "comment": "AI研判结果: 真实/误报/研判要素缺失/失败"
+      },
+      "ai_fields.ai_judgment_level": {
+        "type": "string",
+        "optional": true,
+        "comment": "AI研判等级: -1未知 0无威胁 1低危 2中危 3高危 4超危"
+      },
+      "ai_fields.ai_event_nature": {
+        "type": "string",
+        "optional": true,
+        "comment": "AI事件性质"
+      },
+      "ai_fields.disposal_report": {
+        "type": "string",
+        "optional": true,
+        "comment": "AI处置报告，写入告警字段 ai_disposal_result"
+      },
+      "ai_fields.ai_disposal": {
+        "type": "integer",
+        "optional": true,
+        "comment": "AI是否处置: 0否 1是"
+      },
+      "ai_fields.created_at": {
+        "type": "string",
+        "optional": true,
+        "comment": "可选分区键：告警真实创建时间，RFC3339 格式；不确定时不要传"
+      }
+    },
+    "reply": {}
+  },
+  {
     "name": "JudgeService.MultiJudgeAlert",
     "comment": "批量研判告警",
     "args": {

--- a/products/cosmos/command.go
+++ b/products/cosmos/command.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -35,7 +35,7 @@ func NewCommand() *cobra.Command {
 			continue
 		}
 
-		data, err := apiSpecs.ReadFile(filepath.Join("apis", entry.Name()))
+		data, err := apiSpecs.ReadFile(path.Join("apis", entry.Name()))
 		if err != nil {
 			fmt.Printf("warning: failed to read %s: %v\n", entry.Name(), err)
 			continue
@@ -49,7 +49,7 @@ func NewCommand() *cobra.Command {
 
 		var ops []APIOperation
 		if err := json.Unmarshal(data, &ops); err != nil {
-			name := strings.TrimSuffix(filepath.Base(entry.Name()), ".json")
+			name := strings.TrimSuffix(path.Base(entry.Name()), ".json")
 			fmt.Printf("warning: failed to parse %s: %v\n", name, err)
 			continue
 		}

--- a/products/cosmos/parser_test.go
+++ b/products/cosmos/parser_test.go
@@ -270,6 +270,53 @@ func TestBuildRequestBodyConvertsExplicitEmptyStringSliceToEmptySlice(t *testing
 	}
 }
 
+func TestBuildRequestBodyNestsAIFields(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	flags := []flagDef{
+		{name: "ai_fields.alarm_id", typeName: "string", required: true},
+		{name: "ai_fields.analysis_report", typeName: "string"},
+		{name: "ai_fields.confidence_score", typeName: "integer"},
+		{name: "ai_fields.ai_analysis", typeName: "integer"},
+		{name: "ai_fields.disposal_report", typeName: "string"},
+		{name: "ai_fields.ai_disposal", typeName: "integer"},
+	}
+	values := make(map[string]interface{})
+	for _, f := range flags {
+		bindFlag(cmd, f, values)
+	}
+
+	for name, value := range map[string]string{
+		"ai_fields.alarm_id":         "alarm-1",
+		"ai_fields.analysis_report":  "analysis",
+		"ai_fields.confidence_score": "85",
+		"ai_fields.ai_analysis":      "1",
+		"ai_fields.disposal_report":  "disposal",
+		"ai_fields.ai_disposal":      "1",
+	} {
+		if err := cmd.Flags().Set(name, value); err != nil {
+			t.Fatalf("set %s: %v", name, err)
+		}
+	}
+
+	params := buildRequestBody(cmd, values, flags)
+	aiFields, ok := params["ai_fields"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("ai_fields type = %T, want map[string]interface{}", params["ai_fields"])
+	}
+	for name, want := range map[string]interface{}{
+		"alarm_id":         "alarm-1",
+		"analysis_report":  "analysis",
+		"confidence_score": 85,
+		"ai_analysis":      1,
+		"disposal_report":  "disposal",
+		"ai_disposal":      1,
+	} {
+		if got := aiFields[name]; got != want {
+			t.Errorf("ai_fields.%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
 func firstQueryItem(t *testing.T, params map[string]interface{}, key string) map[string]interface{} {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Add `AlarmService.UpdateAiFieldsContent` to the Cosmos API specifications.
- Expose `cosmos alarm update-ai-fields-content`.
- Build the required nested `params.ai_fields` request structure.
- Document the new command and AI field mappings.
- Use slash-separated paths when loading embedded Cosmos API specifications so command registration works across platforms.

## Example

```bash
chaitin-cli --dry-run cosmos alarm update-ai-fields-content \
  --ai_fields.alarm_id ALARM_ID \
  --ai_fields.analysis_report "AI analysis report" \
  --ai_fields.confidence_score 85 \
  --ai_fields.ai_analysis 1 \
  --ai_fields.ai_judgment_result "误报" \
  --ai_fields.ai_judgment_level "1" \
  --ai_fields.ai_event_nature "业务测试"
  
  ```

## Tests

```text
go test ./products/cosmos
```