### PR TITLE
docs: 完善全悉 CLI 接入和 Agent 使用文档

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -173,6 +173,23 @@ safeline.url         -> SAFELINE_URL
 safeline.api_key     -> SAFELINE_API_KEY
 ```
 
+### T-Answer
+
+T-Answer commands use an OpenAPI Token. Create an API Token in the T-Answer web console under `System Management` -> `Open API`, then configure `tanswer.api_key` or set `TANSWER_API_KEY`.
+
+For T-Answer installation, Token setup, permission requirements, smoke tests, and troubleshooting, see [`products/tanswer/README.md`](products/tanswer/README.md). For the full command reference, see [`products/tanswer/COMMAND_REFERENCE.md`](products/tanswer/COMMAND_REFERENCE.md). For AI Agent rules, see [`products/tanswer/agent-skill.md`](products/tanswer/agent-skill.md).
+
+```bash
+chaitin-cli tanswer manifest
+chaitin-cli tanswer auth check
+chaitin-cli tanswer system status
+chaitin-cli tanswer alarm overview --time today
+chaitin-cli tanswer asset list --page-size 10
+chaitin-cli tanswer response block-policies --page-size 10
+```
+
+Prefer semantic commands such as `alarm`, `file-alarm`, `asset`, `metadata`, `policy`, and `response`. Use `tanswer api <METHOD> <PATH>` only for user-known, authorized Open API endpoints that do not have a semantic command.
+
 ### SafeLine-3
 
 SafeLine-3 commands use an OpenAPI token. Configure `safeline-3.api_token` or set `SAFELINE_3_API_TOKEN`.

--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ npx skills add chaitin/chaitin-cli
 | `cosmos`      | 安全分析与运营管理平台（万象）        | Cosmos / AISOC 告警、日志、情报、封禁、资产、通知、运维、SOAR 和漏洞管理           |
 | `monkeyscan`  | AI 代码安全平台 MonkeyScan      | 本地目录、源码压缩包与 GitHub 仓库全量安全扫描                                 |
 
-
-
 根命令负责配置加载、产品命令注册和 BusyBox 风格调用分发；各产品目录负责自己的命令、参数、配置解析和 API 调用逻辑。
 
 ## 配置
@@ -199,6 +197,23 @@ safeline.api_key     -> SAFELINE_API_KEY
 monkeyscan.url       -> MONKEYSCAN_URL
 monkeyscan.api_key   -> MONKEYSCAN_API_KEY
 ```
+
+### T-Answer
+
+全悉 CLI 使用 OpenAPI Token。请在全悉 Web 控制台的 `系统管理` -> `Open API` 中新增 API Token，并在配置中填写 `tanswer.api_key`，或设置 `TANSWER_API_KEY`。
+
+全悉 CLI 的安装、Token 获取、权限要求、最小可用性验证和常见问题见 [`products/tanswer/README.md`](products/tanswer/README.md)；完整命令参考见 [`products/tanswer/COMMAND_REFERENCE.md`](products/tanswer/COMMAND_REFERENCE.md)；AI Agent 使用规则见 [`products/tanswer/agent-skill.md`](products/tanswer/agent-skill.md)。
+
+```bash
+chaitin-cli tanswer manifest
+chaitin-cli tanswer auth check
+chaitin-cli tanswer system status
+chaitin-cli tanswer alarm overview --time today
+chaitin-cli tanswer asset list --page-size 10
+chaitin-cli tanswer response block-policies --page-size 10
+```
+
+优先使用 `alarm`、`file-alarm`、`asset`、`metadata`、`policy` 和 `response` 语义命令。`tanswer api <METHOD> <PATH>` 仅用于用户已知、已授权且语义命令未覆盖的 Open API。
 
 ### MonkeyScan
 

--- a/products/tanswer/README.md
+++ b/products/tanswer/README.md
@@ -11,6 +11,8 @@
 
 ## 快速开始
 
+先按仓库根目录 [README](../../README.md) 安装 `chaitin-cli`，或从 [GitHub Releases](https://github.com/chaitin/chaitin-cli/releases) 下载对应平台的二进制。
+
 ```bash
 export TANSWER_URL='https://<全悉 Web 端 IP>'
 export TANSWER_API_KEY='<全悉 OpenAPI Token>'
@@ -26,6 +28,21 @@ chaitin-cli tanswer alarm overview --time today
 ```bash
 chaitin-cli tanswer --insecure auth check
 ```
+
+## 最小可用性验证
+
+首次接入或发布新版本后，建议按下面顺序做 smoke test，确认二进制版本、连接配置、Token 权限和核心只读能力可用：
+
+```bash
+chaitin-cli tanswer manifest
+chaitin-cli tanswer auth check
+chaitin-cli tanswer system status
+chaitin-cli tanswer alarm overview --time today
+chaitin-cli tanswer asset list --page-size 5
+chaitin-cli tanswer response block-policies --page-size 5
+```
+
+如果 `manifest` 不存在，通常表示当前安装的 `chaitin-cli` 版本不包含全悉语义 CLI。请先升级到包含 `tanswer` 语义命令的 Release。
 
 ## 快速开始：AI Agent
 
@@ -52,6 +69,17 @@ chaitin-cli tanswer api POST /rpc --body @./request.json
 
 `chaitin-cli tanswer` 支持通过配置文件、环境变量和全局 flag 配置连接信息。
 
+### 获取 OpenAPI Token
+
+在全悉 Web 控制台中生成 OpenAPI Token：
+
+1. 登录全悉 Web 控制台。
+2. 进入 `系统管理` -> `Open API`。
+3. 点击 `新增 API Token`，选择用于 Open API 调用的 Token 类型。
+4. 保存生成出的 Token，并配置到 `TANSWER_API_KEY` 或 `tanswer.api_key`。
+
+API Token 生成后不会持续明文展示，请妥善保存。不要把真实 Token 写入脚本、日志、共享文档、commit message 或 MR 描述。
+
 | 配置 | 说明 |
 | --- | --- |
 | `tanswer.url` / `TANSWER_URL` | 全悉控制台地址，例如 `https://<全悉 Web 端 IP>`。 |
@@ -65,6 +93,23 @@ chaitin-cli tanswer api POST /rpc --body @./request.json
 chaitin-cli tanswer --url 'https://<全悉 Web 端 IP>' --api-key '<全悉 OpenAPI Token>' auth check
 chaitin-cli tanswer --insecure auth check
 ```
+
+### 权限要求
+
+CLI 调用继承全悉现有 OpenAPI Token 的权限、有效期、频率限制和 IP 访问策略。建议按实际自动化范围分配最小权限：
+
+| 使用范围 | 需要的能力 |
+| --- | --- |
+| 只读巡检 | 系统状态、威胁告警、文件告警、资产、元数据、策略和响应记录查询。 |
+| 资产维护 | 资产创建、更新、删除、导入、导出、批量维护和资产组维护。 |
+| 策略维护 | 检测白名单、自定义 IOC 情报的创建、更新、启停、删除、导入和导出。 |
+| 响应处置 | 阻断策略、响应白名单、告警生成处置对象、联动设备配置和自动响应记录查询。 |
+
+如果查询命令可用但写操作失败，优先检查 Token 绑定角色是否包含对应写权限；如果所有命令都失败，先运行 `chaitin-cli tanswer auth check` 排查地址、Token、证书、有效期、IP 策略和频率限制。
+
+### 版本和兼容性
+
+客户端需要使用包含全悉语义命令的 `chaitin-cli` Release。服务端需要开放全悉 OpenAPI TokenAuth 和对应 RPC/Open API 能力。不同全悉版本开放的后端接口可能不同；以 `chaitin-cli tanswer manifest`、本文件和 [COMMAND_REFERENCE.md](./COMMAND_REFERENCE.md) 记录的命令为准。
 
 ## 命令层级
 
@@ -157,6 +202,17 @@ chaitin-cli tanswer response block-policy-create --name block-bad-ip --object 19
 - `file-alarm` 命令只读取文件告警，不下载样本，也不触发新的沙箱分析。
 - `metadata near-alarm` 只提供上下文，不能单独作为攻击证据。
 - `response` 产品记录不能替代第三方联动设备执行证明。
+
+## 常见问题
+
+| 现象 | 处理方式 |
+| --- | --- |
+| `missing Quanxi address` | 设置 `TANSWER_URL`，或在命令中传入 `--url`。 |
+| `missing OpenAPI token` | 设置 `TANSWER_API_KEY`，或在命令中传入 `--api-key`。 |
+| `TOKEN_CHECK_FAILED` | 检查全悉地址、Token 是否正确、Token 是否过期/禁用、IP 访问策略和频率限制。 |
+| TLS 证书校验失败 | 在确需跳过证书校验的环境中使用 `chaitin-cli tanswer --insecure auth check`。 |
+| 命令不存在 | 升级到包含全悉语义 CLI 的 `chaitin-cli` Release，并重新运行 `chaitin-cli tanswer --help`。 |
+| 读命令成功但写命令失败 | 检查 Token 绑定角色是否具备资产维护、策略维护或响应处置写权限。 |
 
 ## 文档索引
 

--- a/products/tanswer/agent-skill.md
+++ b/products/tanswer/agent-skill.md
@@ -1,8 +1,22 @@
 # 全悉 CLI Agent 使用规则
 
-本文档面向使用 `chaitin-cli tanswer` 的 AI Agent，说明命令选择、输出读取、变更确认和安全边界。执行命令前，优先使用 `chaitin-cli tanswer manifest` 获取当前版本支持的命令、参数、输出字段和确认要求。
+本文档面向使用 `chaitin-cli tanswer` 的 AI Agent，说明标准流程、命令选择、输出读取、变更确认和安全边界。执行命令前，优先使用 `chaitin-cli tanswer manifest` 获取当前版本支持的命令、参数、输出字段和确认要求。
 
-## 命令选择
+## 标准执行流程
+
+首次接入一个全悉环境，或用户没有明确说明当前 CLI 已验证时，按下面顺序检查：
+
+```bash
+chaitin-cli tanswer auth status
+chaitin-cli tanswer auth check
+chaitin-cli tanswer manifest
+```
+
+`auth status` 只检查本地是否配置了目标地址和 Token，不校验权限。`auth check` 用只读接口验证 TokenAuth 链路。`manifest` 是命令层级、参数、枚举、风险等级、输出字段和确认要求的当前版本事实来源。
+
+访问凭证应来自配置文件、环境变量或命令行参数。不要把真实 OpenAPI Token 写入提示词、脚本、日志、共享文档、commit message 或 MR 描述。
+
+## 命令选择优先级
 
 优先使用语义命令回答安全运营问题。语义命令按领域组织，例如：
 
@@ -20,18 +34,7 @@ chaitin-cli tanswer api GET /api/example --query '{"count":10,"offset":0}'
 chaitin-cli tanswer api POST /rpc --body @./request.json
 ```
 
-`api` 输出 `status_code` 和 `raw`。不要假设 CLI 内置完整 Open API 文档；调用前必须由用户输入或已授权文档确认 method、path、query 和 body。
-
-## 配置检查
-
-执行业务命令前，可先检查连接配置和授权状态：
-
-```bash
-chaitin-cli tanswer auth status
-chaitin-cli tanswer auth check
-```
-
-访问凭证应来自配置文件、环境变量或命令行参数。不要把真实 OpenAPI Token 写入提示词、脚本、日志、共享文档、commit message 或 MR 描述。
+`api` 输出 `status_code` 和 `raw`。不要假设 CLI 内置完整 Open API 文档；调用前必须由用户输入或已授权文档确认 method、path、query 和 body。不要根据源码片段、猜测或相似产品经验拼 RPC method。
 
 ## 输出读取
 
@@ -41,6 +44,18 @@ chaitin-cli tanswer auth check
 - `success=false`：读取 `error.code`、`error.message` 和 `error.retryable`，再决定重试、请用户补充参数或停止。
 
 不要假设原始产品 API 字段一定存在；以 `COMMAND_REFERENCE.md` 和 `chaitin-cli tanswer manifest` 中记录的输出字段为准。
+
+## 错误处理
+
+遇到失败时先判断错误属于哪一类：
+
+| 错误类型 | 处理方式 |
+| --- | --- |
+| 缺少地址或 Token | 提醒用户配置 `TANSWER_URL`、`TANSWER_API_KEY`，或在命令中传入 `--url`、`--api-key`。 |
+| `TOKEN_CHECK_FAILED` | 检查地址、Token、证书、有效期、IP 访问策略、频率限制和角色权限。 |
+| 参数错误 | 根据 `error.message` 和命令 `--help` 补齐必填参数或修正枚举值。 |
+| 权限不足 | 停止执行写操作，请用户确认 OpenAPI Token 绑定角色是否具备对应权限。 |
+| 可重试错误 | 只有 `error.retryable=true` 且操作是只读命令时，才考虑重试。 |
 
 ## 变更确认
 
@@ -58,6 +73,8 @@ chaitin-cli tanswer auth check
 - `confirmation_token`
 
 不要自动推断或替用户填写确认令牌。只有用户或上游系统明确提供与预览一致的 `confirmation_token` 时，才能使用 `--confirm` 执行。确认令牌大小写敏感。
+
+确认前需要向用户复述目标对象、影响范围、风险提示和确认令牌来源。用户只表达“可以”“执行吧”但没有提供准确确认令牌时，不执行写操作。
 
 执行输出应包含：
 
@@ -79,9 +96,66 @@ chaitin-cli tanswer auth check
 | 查询或维护检测白名单和自定义 IOC 情报 | `policy ...` |
 | 查询或维护阻断策略、响应白名单、联动设备和自动响应记录 | `response ...` |
 
+### 告警路由
+
+- 总览、等级分布、攻击结果分布、攻击源 Top、受害对象 Top：使用 `alarm overview`。
+- 趋势、峰值、按时间观察等级变化：使用 `alarm timeline`。
+- 原始告警行、分页、按攻击源/受害对象/资产 IP/威胁名过滤：使用 `alarm list`。
+- 值班优先处置、critical/high、成功或失陷告警：优先使用 `alarm high-priority`。
+- 单条告警详情：只有拿到 `doc_id` 后使用 `alarm detail`。
+- 围绕一个攻击源、受害对象或威胁名做归因摘要：使用 `alarm by-attacker`、`alarm by-victim`、`alarm by-threat`。
+- 查同一告警附近是否有相关事件：只有拿到源告警 `doc_id` 后使用 `alarm related`。
+
+### 文件告警路由
+
+- 恶意文件、Webshell、沙箱检测风险概览：使用 `file-alarm overview`。
+- 恶意文件列表：使用 `file-alarm malicious`。
+- Webshell 结果：使用 `file-alarm webshell`。
+- 已有沙箱检测结果、沙箱分数、运行环境：使用 `file-alarm sandbox`。
+- 单条文件告警详情：只有拿到 `doc_id` 后使用 `file-alarm detail`。
+- 不使用 `file-alarm` 下载样本、提交样本或触发新的沙箱分析。
+
+### 资产路由
+
+- 查配置资产、按名称/IP/MAC/类型/重要性/标签/资产组过滤：使用 `asset list`。
+- 单资产详情：只有拿到资产 ID 后使用 `asset detail`。
+- 查资产组、组 ID、层级和资产数量：使用 `asset group-tree`。
+- 导入前需要模板：使用 `asset download-template`。
+- 导出资产配置：使用 `asset export`。
+- 创建、更新、删除、导入、批量维护、批量打标签、资产组管理和树层级调整都属于写操作，必须先预览并等待准确确认令牌。
+- 不用资产命令回答漏洞风险、资产风险或风险主机问题；这些不在当前全悉 CLI 范围内。
+
+### 元数据路由
+
+- 按 HTTP、DNS、TCP、UDP 等协议查流量元数据：使用 `metadata protocol`。
+- 用户给出高级查询表达式或精确条件：使用 `metadata search`。
+- 单条元数据详情：只有拿到 `id`、`timestamp` 和 `protocol` 后使用 `metadata detail`。
+- 告警附近流量上下文：只有拿到告警 `doc_id` 后使用 `metadata near-alarm`，结果只能作为调查上下文，不能单独当作攻击证据。
+- 查询或调整协议采集配置：使用 `metadata config` 和 `metadata config-update`；调整配置属于写操作。
+
+### 策略路由
+
+- 查询误报抑制、检测白名单状态、源/目的过滤、域名、URL、User-Agent、XFF、响应码、威胁类型或检测规则 ID：使用 `policy detection-whitelist`。
+- 从已确认误报告警生成检测白名单：只有拿到告警 `doc_id` 且用户明确确认误报后，使用 `policy detection-whitelist-from-alarm --preview`。
+- 查询自定义 IOC 情报、IOC 类型、启停状态和备注：使用 `policy custom-intelligence`。
+- 创建、更新、启用、禁用、删除、导入检测白名单或自定义 IOC 都是写操作，必须先预览并等待准确确认令牌。
+- 不用 policy 命令维护响应白名单、旁路阻断策略或自动响应。
+
+### 响应路由
+
+- 查询旁路阻断策略：使用 `response block-policies`。
+- 查询阻断命中记录：使用 `response block-records`。
+- 查询响应白名单：使用 `response whitelist`。
+- 查询联动设备：使用 `response devices`；不知道设备 ID 时先查设备，再查 `response device-records`。
+- 查询自动响应策略和自动响应生成列表：使用 `response auto-policies`、`response auto-list`。
+- 从告警生成阻断策略或响应白名单：只有拿到告警 `doc_id` 且用户明确选择处置动作后，使用 `response block-policy-from-alarm --preview` 或 `response whitelist-from-alarm --preview`。
+- 不把全悉产品记录当作第三方联动设备已经执行成功的唯一证明。
+
 ## 安全边界
 
 - `file-alarm` 命令只读取文件告警，不下载样本，也不触发新的沙箱分析。
 - `metadata near-alarm` 只提供上下文，不能单独作为攻击证据。
 - `response` 产品记录不能替代第三方联动设备执行证明。
 - 未确认用户意图时，不执行创建、编辑、启用、禁用、删除、导入、处置或白名单类写操作。
+- 不绕过 `chaitin-cli tanswer` 直接用 `curl` 执行全悉写操作。
+- 不根据猜测调用未在 `manifest`、`COMMAND_REFERENCE.md` 或用户授权 Open API 文档中出现的接口。

--- a/skills/chaitin-cli/SKILL.md
+++ b/skills/chaitin-cli/SKILL.md
@@ -775,6 +775,39 @@ chaitin-cli tanswer response block-policies --page-size 10
 
 Use semantic commands first. Use `chaitin-cli tanswer api <METHOD> <PATH>` only for user-known and authorized Open API endpoints that do not have a semantic command.
 
+### Fast Agent Workflow (T-Answer)
+
+Before autonomous T-Answer work, run `chaitin-cli tanswer auth check` and `chaitin-cli tanswer manifest` unless the current session already verified the environment. For create, update, delete, import, enable, disable, or response actions, run the command with `--preview` first and do not fill `--confirm` unless the user or upstream system explicitly provides the exact confirmation token.
+
+For routine read-only tasks, this section is enough. Use `products/tanswer/agent-skill.md` only for complex routing, write-operation planning, or ambiguous policy/response decisions. Use `products/tanswer/COMMAND_REFERENCE.md` when a specific command's full flags, output fields, long examples, or boundaries are needed. Onboarding, Token setup, permission requirements, smoke tests, and troubleshooting live in `products/tanswer/README.md`.
+
+### Quick Routing (T-Answer)
+
+| User intent | Prefer |
+| --- | --- |
+| Verify connection, local config, or Token availability | `tanswer auth status`, `tanswer auth check` |
+| Discover supported commands, flags, risk levels, output fields | `tanswer manifest` |
+| System version, License, node status, health summary | `tanswer system status` |
+| Overall threat posture, alarm distribution, attacker/victim top lists | `tanswer alarm overview` |
+| Critical/high successful or compromised alarms for duty handling | `tanswer alarm high-priority` |
+| Original threat alarm rows or one alarm detail | `tanswer alarm list`, then `tanswer alarm detail --id <doc_id>` |
+| Related alarms around one source alarm | `tanswer alarm related --id <doc_id>` |
+| Malicious file, Webshell, or sandbox-result investigation | `tanswer file-alarm overview`, `malicious`, `webshell`, `sandbox`, `detail` |
+| Configured asset inventory, group tree, import/export, asset maintenance | `tanswer asset ...` |
+| Traffic metadata by protocol, advanced query, detail, or alarm context | `tanswer metadata ...` |
+| Detection whitelist or custom IOC intelligence | `tanswer policy ...` |
+| Bypass block policies, block records, response whitelist, linkage devices, automatic response | `tanswer response ...` |
+
+Use `alarm detail`, `file-alarm detail`, `asset detail`, `metadata detail`, `metadata near-alarm`, and alarm-derived policy/response commands only after the required IDs are available from list/detail commands or the user.
+
+### Safety Rules (T-Answer)
+
+- Do not bypass `chaitin-cli tanswer` with `curl` for state-changing operations.
+- Do not guess RPC methods or request bodies. Use semantic commands, `manifest`, command `--help`, or user-provided authorized Open API documentation.
+- Do not use `file-alarm` to download samples, submit samples, or trigger new sandbox analysis.
+- Treat `metadata near-alarm` as investigation context, not standalone proof of an attack.
+- Do not treat T-Answer response records as proof that a third-party device completed enforcement without separate validation.
+
 ---
 
 ## SafeLine-CE (雷池社区版)


### PR DESCRIPTION
## 背景

本次更新补齐全悉（T-Answer）CLI 面向客户和 AI Agent 使用时的文档入口、接入流程和安全使用规则。当前 PR 仅更新文档，不修改 CLI 行为、不调整 Release 打包逻辑。

## 变更内容

- 在根 `README.md` / `README.en.md` 增加独立的 T-Answer 产品小节
  - 说明 OpenAPI Token 配置方式
  - 增加全悉专门文档入口
  - 增加常用 smoke test 命令
  - 明确语义命令优先，`api` 仅作为兜底入口

- 优化 `products/tanswer/README.md`
  - 补充安装入口
  - 补充 OpenAPI Token 获取路径
  - 补充权限要求
  - 补充最小可用性验证流程
  - 补充版本兼容说明
  - 补充常见问题排查

- 增强 `products/tanswer/agent-skill.md`
  - 补充 Agent 标准执行流程
  - 补充命令选择优先级
  - 补充错误处理规则
  - 补充 preview/confirm 写操作安全规则
  - 补充告警、文件告警、资产、元数据、策略、响应等领域路由

- 优化 `skills/chaitin-cli/SKILL.md` 中的 T-Answer 指引
  - 增加快速 Agent 工作流
  - 增加 T-Answer 快速路由表
  - 增加安全边界
  - 明确普通只读任务无需反复读取全量全悉文档，复杂任务再查看专门文档

## 验证

```bash
git diff --check
env GOCACHE=/private/tmp/chaitin-go-build-cache go test ./products/tanswer
```

## 说明

- 本 PR 不修改 CLI 命令实现。
- 本 PR 不修改 Release 打包逻辑。
- 新版 Release 发布后，客户可按文档通过 `chaitin-cli tanswer manifest`、`auth check`、`system status` 等命令完成最小可用性验证。
