### PR TITLE
support scheduled xray plans

### DIFF
--- a/products/xray/README.md
+++ b/products/xray/README.md
@@ -53,7 +53,7 @@ xray:
 
 ### 创建任务 (PostPlanCreateQuick)
 
-快速创建扫描任务，立即执行（马上扫一次）。
+快速创建立即、单次定时或周期扫描任务。不指定 `--plan-type` 时保持原有行为：创建后立即执行。
 
 ```bash
 chaitin-cli xray plan PostPlanCreateQuick \
@@ -71,6 +71,52 @@ chaitin-cli xray plan PostPlanCreateQuick \
 | `--project-id` | 是 | 项目 ID |
 | `--template-name` | 否 | 模板名称搜索关键字（默认"基础服务漏洞扫描"） |
 | `--name` | 否 | 任务名称（默认 quick-scan） |
+| `--plan-type` | 否 | NOW/CLOCKED/DAY/WEEK/MONTH/MONTH_WEEK（默认 NOW） |
+| `--exec-at` | 按类型 | CLOCKED 使用带时区 RFC3339；周期任务使用 HH:MM 或 HH:MM:SS |
+| `--weekday` | 按类型 | WEEK/MONTH_WEEK 使用，1=周一，...，7=周日 |
+| `--day-of-month` | 按类型 | MONTH 使用，范围 1-31 |
+| `--week-of-month` | 按类型 | MONTH_WEEK 使用，范围 1-4 |
+
+`--exec-at` 表示任务触发时间，不是扫描结束时间。周期计划不会在创建时额外触发扫描。
+
+```bash
+# 每天 10:30 执行
+chaitin-cli xray plan PostPlanCreateQuick \
+  --targets=10.3.0.4 \
+  --engines=00000000000000000000000000000001 \
+  --project-id=1 \
+  --template-name=主机资产监控 \
+  --plan-type=DAY \
+  --exec-at=10:30
+
+# 每月第 2 周的星期五 10:30 执行
+chaitin-cli xray plan PostPlanCreateQuick \
+  --targets=10.3.0.4 \
+  --engines=00000000000000000000000000000001 \
+  --project-id=1 \
+  --plan-type=MONTH_WEEK \
+  --week-of-month=2 \
+  --weekday=5 \
+  --exec-at=10:30
+```
+
+### 更新任务排期 (PostPlanUpdateQuick)
+
+只修改已有任务的排期，保留名称、目标、引擎、扫描配置和执行窗口，并且不会立即触发扫描。
+
+```bash
+# 修改为每周五 11:00 执行
+chaitin-cli xray plan PostPlanUpdateQuick \
+  --id=783 \
+  --plan-type=WEEK \
+  --weekday=5 \
+  --exec-at=11:00
+
+# 保持当前计划类型，只修改触发时间
+chaitin-cli xray plan PostPlanUpdateQuick \
+  --id=783 \
+  --exec-at=12:00
+```
 
 ### 任务列表 (PostPlanFilter)
 

--- a/products/xray/cli/cli.go
+++ b/products/xray/cli/cli.go
@@ -747,6 +747,12 @@ func makeGroupOfOperationsPlanCmd() (*cobra.Command, error) {
 	}
 	parent.AddCommand(sub5)
 
+	sub6, err := makeOperationPlanUpdateQuickCmd()
+	if err != nil {
+		return nil, err
+	}
+	parent.AddCommand(sub6)
+
 	return parent, nil
 } // makeGroupOfOperationsProjectCmd returns a parent command to handle all operations with tag "project"
 func makeGroupOfOperationsProjectCmd() (*cobra.Command, error) {

--- a/products/xray/cli/plan_quick_schedule.go
+++ b/products/xray/cli/plan_quick_schedule.go
@@ -1,0 +1,261 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	planTypeNow       = "NOW"
+	planTypeClocked   = "CLOCKED"
+	planTypeDay       = "DAY"
+	planTypeWeek      = "WEEK"
+	planTypeMonth     = "MONTH"
+	planTypeMonthWeek = "MONTH_WEEK"
+)
+
+var validPlanTypes = map[string]struct{}{
+	planTypeNow: {}, planTypeClocked: {}, planTypeDay: {},
+	planTypeWeek: {}, planTypeMonth: {}, planTypeMonthWeek: {},
+}
+
+var weekdayNames = map[int]string{
+	1: "MON", 2: "TUES", 3: "WED", 4: "THUR", 5: "FRI", 6: "SAT", 7: "SUN",
+}
+
+type quickScheduleInput struct {
+	planType       string
+	planTypeSet    bool
+	execAt         string
+	execAtSet      bool
+	weekday        int
+	weekdaySet     bool
+	dayOfMonth     int
+	dayOfMonthSet  bool
+	weekOfMonth    int
+	weekOfMonthSet bool
+}
+
+func registerQuickScheduleFlags(cmd *cobra.Command, defaultPlanType string) {
+	cmd.Flags().String("plan-type", defaultPlanType, "计划类型: NOW, CLOCKED, DAY, WEEK, MONTH, MONTH_WEEK")
+	cmd.Flags().String("exec-at", "", "触发时间；CLOCKED 使用带时区 RFC3339，周期任务使用 HH:MM 或 HH:MM:SS")
+	cmd.Flags().Int("weekday", 0, "星期几，仅 WEEK/MONTH_WEEK 使用：1=周一 ... 7=周日")
+	cmd.Flags().Int("day-of-month", 0, "每月第几日，仅 MONTH 使用，范围 1-31")
+	cmd.Flags().Int("week-of-month", 0, "每月第几周，仅 MONTH_WEEK 使用，范围 1-4")
+}
+
+func readQuickScheduleInput(cmd *cobra.Command) (quickScheduleInput, error) {
+	planType, err := cmd.Flags().GetString("plan-type")
+	if err != nil {
+		return quickScheduleInput{}, err
+	}
+	execAt, err := cmd.Flags().GetString("exec-at")
+	if err != nil {
+		return quickScheduleInput{}, err
+	}
+	weekday, err := cmd.Flags().GetInt("weekday")
+	if err != nil {
+		return quickScheduleInput{}, err
+	}
+	dayOfMonth, err := cmd.Flags().GetInt("day-of-month")
+	if err != nil {
+		return quickScheduleInput{}, err
+	}
+	weekOfMonth, err := cmd.Flags().GetInt("week-of-month")
+	if err != nil {
+		return quickScheduleInput{}, err
+	}
+
+	return quickScheduleInput{
+		planType:       strings.ToUpper(strings.TrimSpace(planType)),
+		planTypeSet:    cmd.Flags().Changed("plan-type"),
+		execAt:         strings.TrimSpace(execAt),
+		execAtSet:      cmd.Flags().Changed("exec-at"),
+		weekday:        weekday,
+		weekdaySet:     cmd.Flags().Changed("weekday"),
+		dayOfMonth:     dayOfMonth,
+		dayOfMonthSet:  cmd.Flags().Changed("day-of-month"),
+		weekOfMonth:    weekOfMonth,
+		weekOfMonthSet: cmd.Flags().Changed("week-of-month"),
+	}, nil
+}
+
+func (in quickScheduleInput) changed() bool {
+	return in.planTypeSet || in.execAtSet || in.weekdaySet || in.dayOfMonthSet || in.weekOfMonthSet
+}
+
+func buildPlanSetting(in quickScheduleInput, existing map[string]any) (map[string]any, error) {
+	planType := in.planType
+	if planType == "" && existing != nil {
+		planType, _ = existing["planType"].(string)
+		planType = strings.ToUpper(planType)
+	}
+	if _, ok := validPlanTypes[planType]; !ok {
+		return nil, fmt.Errorf("invalid plan-type %q; expected NOW, CLOCKED, DAY, WEEK, MONTH, or MONTH_WEEK", planType)
+	}
+
+	setting := map[string]any{"enabled": true, "planType": planType}
+	switch planType {
+	case planTypeNow:
+		if in.execAtSet || in.weekdaySet || in.dayOfMonthSet || in.weekOfMonthSet {
+			return nil, fmt.Errorf("plan-type NOW does not accept scheduling flags")
+		}
+	case planTypeClocked:
+		if in.weekdaySet || in.dayOfMonthSet || in.weekOfMonthSet {
+			return nil, fmt.Errorf("plan-type CLOCKED only accepts --exec-at")
+		}
+		runAt := in.execAt
+		if runAt == "" && existing != nil {
+			runAt, _ = existing["startTime"].(string)
+		}
+		parsed, err := time.Parse(time.RFC3339, runAt)
+		if err != nil {
+			return nil, fmt.Errorf("--exec-at must be RFC3339 with timezone for CLOCKED: %w", err)
+		}
+		setting["startTime"] = parsed.Format(time.RFC3339)
+	case planTypeDay:
+		if in.weekdaySet || in.dayOfMonthSet || in.weekOfMonthSet {
+			return nil, fmt.Errorf("plan-type DAY only accepts --exec-at")
+		}
+		execAt, err := resolveExecTime(in, existing, nil)
+		if err != nil {
+			return nil, err
+		}
+		setting["execTime"] = execAt
+	case planTypeWeek:
+		if in.dayOfMonthSet || in.weekOfMonthSet {
+			return nil, fmt.Errorf("plan-type WEEK only accepts --exec-at and --weekday")
+		}
+		appoint := existingAppoint(existing)
+		execAt, err := resolveExecTime(in, nil, appoint)
+		if err != nil {
+			return nil, err
+		}
+		weekday, err := resolveInt(in.weekday, in.weekdaySet, appoint, "weekday")
+		if err != nil || weekday < 1 || weekday > 7 {
+			return nil, fmt.Errorf("--weekday is required and must be between 1 and 7")
+		}
+		setting["appoints"] = []any{map[string]any{"weekday": weekdayNames[weekday], "execTime": execAt}}
+	case planTypeMonth:
+		if in.weekdaySet || in.weekOfMonthSet {
+			return nil, fmt.Errorf("plan-type MONTH only accepts --exec-at and --day-of-month")
+		}
+		appoint := existingAppoint(existing)
+		execAt, err := resolveExecTime(in, nil, appoint)
+		if err != nil {
+			return nil, err
+		}
+		day, err := resolveInt(in.dayOfMonth, in.dayOfMonthSet, appoint, "day")
+		if err != nil || day < 1 || day > 31 {
+			return nil, fmt.Errorf("--day-of-month is required and must be between 1 and 31")
+		}
+		setting["appoints"] = []any{map[string]any{"day": day, "execTime": execAt}}
+	case planTypeMonthWeek:
+		if in.dayOfMonthSet {
+			return nil, fmt.Errorf("plan-type MONTH_WEEK only accepts --exec-at, --weekday, and --week-of-month")
+		}
+		appoint := existingAppoint(existing)
+		execAt, err := resolveExecTime(in, nil, appoint)
+		if err != nil {
+			return nil, err
+		}
+		weekday, err := resolveInt(in.weekday, in.weekdaySet, appoint, "weekday")
+		if err != nil || weekday < 1 || weekday > 7 {
+			return nil, fmt.Errorf("--weekday is required and must be between 1 and 7")
+		}
+		week, err := resolveInt(in.weekOfMonth, in.weekOfMonthSet, appoint, "week")
+		if err != nil || week < 1 || week > 4 {
+			return nil, fmt.Errorf("--week-of-month is required and must be between 1 and 4")
+		}
+		setting["appoints"] = []any{map[string]any{
+			"week": week, "weekday": weekdayNames[weekday], "execTime": execAt,
+		}}
+	}
+	return setting, nil
+}
+
+func resolveExecTime(in quickScheduleInput, setting, appoint map[string]any) (string, error) {
+	value := in.execAt
+	if value == "" && appoint != nil {
+		value, _ = appoint["execTime"].(string)
+	}
+	if value == "" && setting != nil {
+		value, _ = setting["execTime"].(string)
+	}
+	for _, layout := range []string{"15:04", "15:04:05"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.Format("15:04:05"), nil
+		}
+	}
+	return "", fmt.Errorf("--exec-at is required and must use HH:MM or HH:MM:SS")
+}
+
+func existingAppoint(setting map[string]any) map[string]any {
+	if setting == nil {
+		return nil
+	}
+	items, ok := setting["appoints"].([]any)
+	if !ok || len(items) == 0 {
+		return nil
+	}
+	appoint, _ := items[0].(map[string]any)
+	return appoint
+}
+
+func resolveInt(value int, changed bool, existing map[string]any, key string) (int, error) {
+	if changed {
+		return value, nil
+	}
+	if existing == nil {
+		return 0, fmt.Errorf("missing %s", key)
+	}
+	switch raw := existing[key].(type) {
+	case float64:
+		return int(raw), nil
+	case int:
+		return raw, nil
+	case string:
+		for number, name := range weekdayNames {
+			if raw == name {
+				return number, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("missing %s", key)
+}
+
+func validateSupportedPlanType(planType string, allowed []string) error {
+	if len(allowed) == 0 {
+		return nil
+	}
+	for _, item := range allowed {
+		if strings.EqualFold(item, planType) {
+			return nil
+		}
+	}
+	sort.Strings(allowed)
+	return fmt.Errorf("plan-type %s is not supported by this template; supported types: %s", planType, strings.Join(allowed, ", "))
+}
+
+func supportedPlanTypes(schema any) []string {
+	root, ok := schema.(map[string]any)
+	if !ok {
+		return nil
+	}
+	properties, _ := root["properties"].(map[string]any)
+	planSetting, _ := properties["planSetting"].(map[string]any)
+	planProperties, _ := planSetting["properties"].(map[string]any)
+	planType, _ := planProperties["planType"].(map[string]any)
+	values, _ := planType["enum"].([]any)
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if text, ok := value.(string); ok {
+			result = append(result, text)
+		}
+	}
+	return result
+}

--- a/products/xray/cli/plan_quick_schedule_test.go
+++ b/products/xray/cli/plan_quick_schedule_test.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/chaitin/chaitin-cli/products/xray/models"
+	"github.com/spf13/cobra"
+)
+
+func TestBuildPlanSetting(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   quickScheduleInput
+		want    map[string]any
+		wantErr string
+	}{
+		{
+			name:  "now",
+			input: quickScheduleInput{planType: planTypeNow},
+			want:  map[string]any{"enabled": true, "planType": planTypeNow},
+		},
+		{
+			name:  "clocked",
+			input: quickScheduleInput{planType: planTypeClocked, execAt: "2026-08-05T10:30:00+08:00", execAtSet: true},
+			want:  map[string]any{"enabled": true, "planType": planTypeClocked, "startTime": "2026-08-05T10:30:00+08:00"},
+		},
+		{
+			name:  "day normalizes time",
+			input: quickScheduleInput{planType: planTypeDay, execAt: "10:30", execAtSet: true},
+			want:  map[string]any{"enabled": true, "planType": planTypeDay, "execTime": "10:30:00"},
+		},
+		{
+			name:  "week maps friday",
+			input: quickScheduleInput{planType: planTypeWeek, execAt: "10:30", execAtSet: true, weekday: 5, weekdaySet: true},
+			want: map[string]any{"enabled": true, "planType": planTypeWeek, "appoints": []any{
+				map[string]any{"weekday": "FRI", "execTime": "10:30:00"},
+			}},
+		},
+		{
+			name:  "month",
+			input: quickScheduleInput{planType: planTypeMonth, execAt: "10:30:45", execAtSet: true, dayOfMonth: 15, dayOfMonthSet: true},
+			want: map[string]any{"enabled": true, "planType": planTypeMonth, "appoints": []any{
+				map[string]any{"day": 15, "execTime": "10:30:45"},
+			}},
+		},
+		{
+			name: "month week maps sunday",
+			input: quickScheduleInput{
+				planType: planTypeMonthWeek, execAt: "10:30", execAtSet: true,
+				weekday: 7, weekdaySet: true, weekOfMonth: 4, weekOfMonthSet: true,
+			},
+			want: map[string]any{"enabled": true, "planType": planTypeMonthWeek, "appoints": []any{
+				map[string]any{"week": 4, "weekday": "SUN", "execTime": "10:30:00"},
+			}},
+		},
+		{
+			name:    "weekday out of range",
+			input:   quickScheduleInput{planType: planTypeWeek, execAt: "10:30", weekday: 8, weekdaySet: true},
+			wantErr: "between 1 and 7",
+		},
+		{
+			name:    "month day out of range",
+			input:   quickScheduleInput{planType: planTypeMonth, execAt: "10:30", dayOfMonth: 32, dayOfMonthSet: true},
+			wantErr: "between 1 and 31",
+		},
+		{
+			name:    "now rejects schedule",
+			input:   quickScheduleInput{planType: planTypeNow, execAt: "10:30", execAtSet: true},
+			wantErr: "does not accept",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := buildPlanSetting(tt.input, nil)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("buildPlanSetting() error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildPlanSetting() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("buildPlanSetting() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildPlanSettingPreservesExistingScheduleValues(t *testing.T) {
+	t.Parallel()
+	existing := map[string]any{
+		"enabled":  true,
+		"planType": planTypeWeek,
+		"appoints": []any{map[string]any{"weekday": "MON", "execTime": "09:00:00"}},
+	}
+	got, err := buildPlanSetting(quickScheduleInput{execAt: "11:30", execAtSet: true}, existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"enabled":  true,
+		"planType": planTypeWeek,
+		"appoints": []any{map[string]any{"weekday": "MON", "execTime": "11:30:00"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildPlanSetting() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSupportedPlanTypes(t *testing.T) {
+	t.Parallel()
+	schema := map[string]any{"properties": map[string]any{
+		"planSetting": map[string]any{"properties": map[string]any{
+			"planType": map[string]any{"enum": []any{"DAY", "WEEK", "MONTH"}},
+		}},
+	}}
+	want := []string{"DAY", "WEEK", "MONTH"}
+	if got := supportedPlanTypes(schema); !reflect.DeepEqual(got, want) {
+		t.Fatalf("supportedPlanTypes() = %v, want %v", got, want)
+	}
+	if err := validateSupportedPlanType("NOW", want); err == nil {
+		t.Fatal("validateSupportedPlanType() expected an error")
+	}
+}
+
+func TestQuickCommandHelp(t *testing.T) {
+	t.Parallel()
+	create, err := makeOperationPlanCreateQuickCmd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	update, err := makeOperationPlanUpdateQuickCmd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, cmd := range []*cobra.Command{create, update} {
+		text := cmd.Long + cmd.Flags().FlagUsages()
+		for _, expected := range []string{"--exec-at", "--weekday", "1=周一", "7=周日", "--day-of-month", "--week-of-month", "MONTH_WEEK", "示例"} {
+			if !strings.Contains(text, expected) {
+				t.Errorf("%s help does not contain %q", cmd.Name(), expected)
+			}
+		}
+	}
+}
+
+func TestQuickCommandsAreRegistered(t *testing.T) {
+	t.Parallel()
+	planCommand, err := makeGroupOfOperationsPlanCmd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"PostPlanCreateQuick", "PostPlanUpdateQuick"} {
+		command, _, err := planCommand.Find([]string{name})
+		if err != nil || command == nil || command.Name() != name {
+			t.Fatalf("plan command %q is not registered", name)
+		}
+	}
+}
+
+func TestUpdatePlanBodyMarshalsBasicSettingAsObject(t *testing.T) {
+	t.Parallel()
+	id := int64(42)
+	execRightNow := false
+	body, err := json.Marshal(models.UpdatePlanBody{
+		ID:           &id,
+		ExecRightNow: &execRightNow,
+		BasicSetting: map[string]any{"planSetting": map[string]any{"planType": planTypeDay}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), `"basic_setting":"`) {
+		t.Fatalf("basic_setting was encoded as a JSON string: %s", body)
+	}
+}

--- a/products/xray/cli/post_plan_quick_operation.go
+++ b/products/xray/cli/post_plan_quick_operation.go
@@ -19,12 +19,26 @@ const defaultBuiltinTemplateName = "基础服务漏洞扫描"
 func makeOperationPlanCreateQuickCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "PostPlanCreateQuick",
-		Short: "快速创建扫描任务（马上扫一次）",
-		Long: fmt.Sprintf(`快速创建扫描任务，立即执行。
+		Short: "快速创建立即或定时扫描任务",
+		Long: fmt.Sprintf(`快速创建立即、单次定时或周期扫描任务。
+
+排期参数：
+  NOW         不需要排期参数，创建后立即执行
+  CLOCKED     --exec-at 使用带时区 RFC3339，例如 2026-08-05T10:30:00+08:00
+  DAY         --exec-at 使用 HH:MM 或 HH:MM:SS
+  WEEK        额外要求 --weekday，1=周一 ... 7=周日
+  MONTH       额外要求 --day-of-month，范围 1-31
+  MONTH_WEEK  额外要求 --week-of-month 1-4 和 --weekday 1-7
+
+--exec-at 表示任务触发时间，不是扫描结束时间。
 
 示例：
-  xray plan quick --targets=example.com --engines=00000000000000000000000000000001 --project-id=1
-  xray plan quick --targets=example.com,example2.com --engines=engine1,engine2 --name=my-scan --project-id=1
+  xray plan PostPlanCreateQuick --targets=example.com --engines=engine1 --project-id=1
+  xray plan PostPlanCreateQuick --targets=example.com --engines=engine1 --project-id=1 --plan-type=CLOCKED --exec-at=2026-08-05T10:30:00+08:00
+  xray plan PostPlanCreateQuick --targets=example.com --engines=engine1 --project-id=1 --plan-type=DAY --exec-at=10:30
+  xray plan PostPlanCreateQuick --targets=example.com --engines=engine1 --project-id=1 --plan-type=WEEK --weekday=5 --exec-at=10:30
+  xray plan PostPlanCreateQuick --targets=example.com --engines=engine1 --project-id=1 --plan-type=MONTH --day-of-month=15 --exec-at=10:30
+  xray plan PostPlanCreateQuick --targets=example.com --engines=engine1 --project-id=1 --plan-type=MONTH_WEEK --week-of-month=2 --weekday=5 --exec-at=10:30
 
 默认使用"基础服务漏洞扫描"(BUILTIN)模板。`),
 		RunE: runOperationPlanQuick,
@@ -35,6 +49,7 @@ func makeOperationPlanCreateQuickCmd() (*cobra.Command, error) {
 	cmd.Flags().String("name", "quick-scan", "任务名称")
 	cmd.Flags().Int64("project-id", 0, "工作区 ID (必填)")
 	cmd.Flags().String("template-name", "", fmt.Sprintf("模板名称 (默认: %s)", defaultBuiltinTemplateName))
+	registerQuickScheduleFlags(cmd, planTypeNow)
 
 	return cmd, nil
 }
@@ -50,14 +65,22 @@ func runOperationPlanQuick(cmd *cobra.Command, args []string) error {
 	name, _ := cmd.Flags().GetString("name")
 	projectID, _ := cmd.Flags().GetInt64("project-id")
 	templateNameFlag, _ := cmd.Flags().GetString("template-name")
+	scheduleInput, err := readQuickScheduleInput(cmd)
+	if err != nil {
+		return err
+	}
+	planSetting, err := buildPlanSetting(scheduleInput, nil)
+	if err != nil {
+		return err
+	}
 
-	targets := strings.Split(targetsStr, ",")
-	engines := strings.Split(enginesStr, ",")
+	targets := parseCommaSeparated(targetsStr)
+	engines := parseCommaSeparated(enginesStr)
 
-	if targetsStr == "" {
+	if len(targets) == 0 {
 		return fmt.Errorf("targets is required")
 	}
-	if enginesStr == "" {
+	if len(engines) == 0 {
 		return fmt.Errorf("engines is required")
 	}
 	if projectID == 0 {
@@ -70,12 +93,15 @@ func runOperationPlanQuick(cmd *cobra.Command, args []string) error {
 		templateName = defaultBuiltinTemplateName
 	}
 
-	templateID, taskSetting, err := findBuiltinTemplateWithTaskSetting(appCli, templateName)
+	templateID, taskSetting, allowedPlanTypes, err := findBuiltinTemplateWithTaskSetting(appCli, templateName)
 	if err != nil {
 		return err
 	}
 	if templateID == 0 {
 		return fmt.Errorf("未找到模板: %s", templateName)
+	}
+	if err := validateSupportedPlanType(scheduleInput.planType, allowedPlanTypes); err != nil {
+		return err
 	}
 	logDebugf("Found template ID %d for '%s'", templateID, templateName)
 
@@ -94,16 +120,13 @@ func runOperationPlanQuick(cmd *cobra.Command, args []string) error {
 			"timeRanges": []interface{}{map[string]interface{}{}},
 			"timeType":   "DAY",
 		},
-		"planSetting": map[string]interface{}{
-			"enabled":  true,
-			"planType": "NOW",
-		},
+		"planSetting":  planSetting,
 		"engineChoice": engines,
 		"taskName":     name,
 	}
 
 	active := true
-	execRightNow := true
+	execRightNow := scheduleInput.planType == planTypeNow
 
 	body := &models.CreatePlanBody{
 		Active:               &active,
@@ -137,19 +160,20 @@ func runOperationPlanQuick(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// findBuiltinTemplateWithTaskSetting fetches templates and finds the one matching the given name with BUILTIN type, returns id and task_setting
-func findBuiltinTemplateWithTaskSetting(appCli *client.OPENAPI, name string) (int64, interface{}, error) {
+// findBuiltinTemplateWithTaskSetting finds a matching built-in template and
+// returns the values needed to build and validate a plan request.
+func findBuiltinTemplateWithTaskSetting(appCli *client.OPENAPI, name string) (int64, interface{}, []string, error) {
 	params := template.NewGetTemplateSummaryParams()
 	params.Limit = 100
 	params.Offset = 0
 
 	result, err := appCli.Template.GetTemplateSummary(params, nil)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to fetch templates: %w", err)
+		return 0, nil, nil, fmt.Errorf("failed to fetch templates: %w", err)
 	}
 
 	if result.Payload == nil || result.Payload.Data == nil || result.Payload.Data.Content == nil {
-		return 0, nil, fmt.Errorf("empty template response")
+		return 0, nil, nil, fmt.Errorf("empty template response")
 	}
 
 	for _, t := range result.Payload.Data.Content {
@@ -157,39 +181,49 @@ func findBuiltinTemplateWithTaskSetting(appCli *client.OPENAPI, name string) (in
 			if *t.TemplateType == "BUILTIN" && strings.Contains(*t.Name, name) {
 				if t.ID != nil {
 					// Fetch full template to get task_setting
-					taskSetting, err := getTemplateTaskSetting(appCli, *t.ID)
+					taskSetting, allowedPlanTypes, err := getTemplateSettings(appCli, *t.ID)
 					if err != nil {
-						return 0, nil, err
+						return 0, nil, nil, err
 					}
-					return *t.ID, taskSetting, nil
+					return *t.ID, taskSetting, allowedPlanTypes, nil
 				}
 			}
 		}
 	}
 
-	return 0, nil, nil
+	return 0, nil, nil, nil
 }
 
-// getTemplateTaskSetting fetches the task_setting for a given template ID
-func getTemplateTaskSetting(appCli *client.OPENAPI, templateID int64) (interface{}, error) {
+// getTemplateSettings fetches task settings and supported plan types for a template.
+func getTemplateSettings(appCli *client.OPENAPI, templateID int64) (interface{}, []string, error) {
 	params := template.NewGetTemplateIDParams()
 	params.ID = templateID
 
 	result, err := appCli.Template.GetTemplateID(params, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch template %d: %w", templateID, err)
+		return nil, nil, fmt.Errorf("failed to fetch template %d: %w", templateID, err)
 	}
 
 	if result.Payload == nil || result.Payload.Data == nil {
-		return nil, fmt.Errorf("template %d not found", templateID)
+		return nil, nil, fmt.Errorf("template %d not found", templateID)
 	}
 
+	var allowedPlanTypes []string
+	if strategy := result.Payload.Data.Strategy; strategy != nil && strategy.BasicSetting != nil {
+		allowedPlanTypes = supportedPlanTypes(strategy.BasicSetting.JSONSchema)
+	}
 	taskSetting := result.Payload.Data.TaskSetting
-	if taskSetting == nil {
-		return nil, nil
-	}
-
-	// TaskSetting is already interface{} (map), go-swagger handles JSON correctly
 	logDebugf("Got task_setting from template API (type: %T)", taskSetting)
-	return taskSetting, nil
+	return taskSetting, allowedPlanTypes, nil
+}
+
+func parseCommaSeparated(value string) []string {
+	items := strings.Split(value, ",")
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if item = strings.TrimSpace(item); item != "" {
+			result = append(result, item)
+		}
+	}
+	return result
 }

--- a/products/xray/cli/post_plan_update_quick_operation.go
+++ b/products/xray/cli/post_plan_update_quick_operation.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/chaitin/chaitin-cli/products/xray/client/plan"
+	"github.com/chaitin/chaitin-cli/products/xray/models"
+	"github.com/spf13/cobra"
+)
+
+func makeOperationPlanUpdateQuickCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "PostPlanUpdateQuick",
+		Short: "快速修改扫描任务的排期",
+		Long: `只修改已有任务的排期，不修改名称、目标、引擎、扫描配置或执行窗口，也不会立即触发扫描。
+
+排期参数：
+  CLOCKED     --exec-at 使用带时区 RFC3339，例如 2026-08-05T10:30:00+08:00
+  DAY         --exec-at 使用 HH:MM 或 HH:MM:SS
+  WEEK        额外要求 --weekday，1=周一 ... 7=周日
+  MONTH       额外要求 --day-of-month，范围 1-31
+  MONTH_WEEK  额外要求 --week-of-month 1-4 和 --weekday 1-7
+
+省略 --plan-type 时沿用任务当前类型。--exec-at 表示任务触发时间，不是扫描结束时间。
+
+示例：
+  xray plan PostPlanUpdateQuick --id=123 --exec-at=11:00
+  xray plan PostPlanUpdateQuick --id=123 --plan-type=DAY --exec-at=10:30
+  xray plan PostPlanUpdateQuick --id=123 --plan-type=WEEK --weekday=5 --exec-at=10:30
+  xray plan PostPlanUpdateQuick --id=123 --plan-type=MONTH --day-of-month=15 --exec-at=10:30
+  xray plan PostPlanUpdateQuick --id=123 --plan-type=MONTH_WEEK --week-of-month=2 --weekday=5 --exec-at=10:30`,
+		RunE: runOperationPlanUpdateQuick,
+	}
+	cmd.Flags().Int64("id", 0, "任务计划 ID (必填)")
+	registerQuickScheduleFlags(cmd, "")
+	return cmd, nil
+}
+
+func runOperationPlanUpdateQuick(cmd *cobra.Command, args []string) error {
+	id, err := cmd.Flags().GetInt64("id")
+	if err != nil {
+		return err
+	}
+	if id <= 0 {
+		return fmt.Errorf("--id is required and must be greater than zero")
+	}
+	input, err := readQuickScheduleInput(cmd)
+	if err != nil {
+		return err
+	}
+	if !input.changed() {
+		return fmt.Errorf("at least one scheduling flag must be provided")
+	}
+
+	appCli, err := makeClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	getResult, err := appCli.Plan.GetPlanID(plan.NewGetPlanIDParams().WithID(id), nil)
+	if err != nil {
+		return fmt.Errorf("failed to fetch plan %d: %w", id, err)
+	}
+	if getResult.Payload == nil || getResult.Payload.Data == nil {
+		return fmt.Errorf("plan %d returned an empty response", id)
+	}
+	current := getResult.Payload.Data
+	basicSetting, err := cloneObject(current.BasicSetting)
+	if err != nil {
+		return fmt.Errorf("plan %d has invalid basic_setting: %w", id, err)
+	}
+	existingPlanSetting, _ := basicSetting["planSetting"].(map[string]any)
+	planSetting, err := buildPlanSetting(input, existingPlanSetting)
+	if err != nil {
+		return err
+	}
+	if current.Strategy != nil && current.Strategy.BasicSetting != nil {
+		if err := validateSupportedPlanType(planSetting["planType"].(string), supportedPlanTypes(current.Strategy.BasicSetting.JSONSchema)); err != nil {
+			return err
+		}
+	}
+	basicSetting["planSetting"] = planSetting
+
+	execRightNow := false
+	params := plan.NewPostPlanUpdateParams()
+	params.Body = &models.UpdatePlanBody{ID: &id, ExecRightNow: &execRightNow, BasicSetting: basicSetting}
+	if dryRun {
+		logDebugf("dry-run flag specified. Skip sending request.")
+		if body, marshalErr := json.MarshalIndent(params.Body, "", "  "); marshalErr == nil {
+			logDebugf("Request body: %s", body)
+		}
+		return nil
+	}
+
+	message, err := parseOperationPlanPostPlanUpdateResult(appCli.Plan.PostPlanUpdate(params, nil))
+	if err != nil {
+		return err
+	}
+	if !debug {
+		fmt.Println(message)
+	}
+	return nil
+}
+
+func cloneObject(value any) (map[string]any, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	if err := json.Unmarshal(encoded, &result); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, fmt.Errorf("expected JSON object")
+	}
+	return result, nil
+}

--- a/products/xray/models/update_plan_body.go
+++ b/products/xray/models/update_plan_body.go
@@ -17,7 +17,7 @@ import (
 type UpdatePlanBody struct {
 
 	// Plan 的一些设置，是个 json
-	BasicSetting string `json:"basic_setting,omitempty"`
+	BasicSetting any `json:"basic_setting,omitempty"`
 
 	// true 为保存并立即执行，即立即执行一次，不影响排期
 	// Required: true


### PR DESCRIPTION
## Changes

- extend `PostPlanCreateQuick` to support `NOW`, `CLOCKED`, `DAY`, `WEEK`, `MONTH`, and `MONTH_WEEK`
- add `PostPlanUpdateQuick` to update scheduling while preserving targets, engines, task settings, and execution windows
- add unified `--exec-at` plus numeric `--weekday` (1=Monday ... 7=Sunday), `--day-of-month`, and `--week-of-month`
- validate plan types against each template's OpenAPI JSON schema
- document conditions, mappings, and runnable examples in command help and the XRay README
- encode update `basic_setting` as a JSON object, matching the server API

## Why

The generated general-purpose create/update commands are intentionally hidden because their request bodies are too complex. The existing quick command only created immediate (`NOW`) scans, so scheduled templates such as 主机资产监控 could not be managed from the CLI.

## Compatibility and impact

- existing `PostPlanCreateQuick` calls remain immediate by default
- scheduled create/update requests set `exec_right_now=false`
- `PostPlanUpdateQuick` changes only `planSetting`
- no config, environment variable, or secret changes

## Root cause

The quick wrapper hard-coded `planType=NOW` and `exec_right_now=true`, and there was no safe update wrapper around the complex generated update API.

## Checks

- `task test`
- `task lint`
- `task build`
- `git diff --check`
- verified create/update `--help` output
- test environment dry-run verified the 主机资产监控 schema and generated DAY request body
- real create reached the test server but was rejected with `TASK_SETTING_ERROR` for the template-provided default task settings; no scan or test task was created
