### PR TITLE
omit null xray request slices

### DIFF
--- a/products/xray/cli/filter_vuln_body_model.go
+++ b/products/xray/cli/filter_vuln_body_model.go
@@ -94,6 +94,10 @@ func registerModelFilterVulnBodyFlags(depth int, cmdPrefix string, cmd *cobra.Co
 		return err
 	}
 
+	if err := registerFilterVulnBodyPropXprocessID(depth, cmdPrefix, cmd); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -306,6 +310,16 @@ func registerFilterVulnBodyPropUpdatedTime(depth int, cmdPrefix string, cmd *cob
 	return nil
 }
 
+func registerFilterVulnBodyPropXprocessID(depth int, cmdPrefix string, cmd *cobra.Command) error {
+	if depth > maxDepth {
+		return nil
+	}
+
+	flagName := fmt.Sprintf("%v.xprocess_id", cmdPrefix)
+	_ = cmd.PersistentFlags().Int64(flagName, 0, "任务实例 ID")
+	return nil
+}
+
 // retrieve flags from commands, and set value in model. Return true if any flag is passed by user to fill model field.
 func retrieveModelFilterVulnBodyFlags(depth int, m *models.FilterVulnBody, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
@@ -424,6 +438,12 @@ func retrieveModelFilterVulnBodyFlags(depth int, m *models.FilterVulnBody, cmdPr
 		return err, false
 	}
 	retAdded = retAdded || UpdatedTimeAdded
+
+	err, XprocessIDAdded := retrieveFilterVulnBodyPropXprocessIDFlags(depth, m, cmdPrefix, cmd)
+	if err != nil {
+		return err, false
+	}
+	retAdded = retAdded || XprocessIDAdded
 
 	return nil, retAdded
 }
@@ -718,4 +738,21 @@ func retrieveFilterVulnBodyPropUpdatedTimeFlags(depth int, m *models.FilterVulnB
 	}
 
 	return nil, retAdded
+}
+
+func retrieveFilterVulnBodyPropXprocessIDFlags(depth int, m *models.FilterVulnBody, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+	if depth > maxDepth {
+		return nil, false
+	}
+
+	flagName := fmt.Sprintf("%v.xprocess_id", cmdPrefix)
+	if !cmd.Flags().Changed(flagName) {
+		return nil, false
+	}
+	value, err := cmd.Flags().GetInt64(flagName)
+	if err != nil {
+		return err, false
+	}
+	m.XprocessID = value
+	return nil, true
 }

--- a/products/xray/cli/post_vuln_filter_operation.go
+++ b/products/xray/cli/post_vuln_filter_operation.go
@@ -5,6 +5,8 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/chaitin/chaitin-cli/products/xray/client/vulnerability"
 	"github.com/chaitin/chaitin-cli/products/xray/models"
@@ -94,7 +96,7 @@ func retrieveOperationVulnerabilityPostVulnFilterBodyFlag(m *vulnerability.PostV
 		}
 
 		flagBodyValue := models.FilterVulnBody{}
-		if err := json.Unmarshal([]byte(flagBodyValueStr), &flagBodyValue); err != nil {
+		if err := decodeFilterVulnBody(flagBodyValueStr, &flagBodyValue); err != nil {
 			return fmt.Errorf("cannot unmarshal body string in models.FilterVulnBody: %w", err), false
 		}
 		m.Body = &flagBodyValue
@@ -122,6 +124,36 @@ func retrieveOperationVulnerabilityPostVulnFilterBodyFlag(m *vulnerability.PostV
 	retAdded = retAdded || added
 
 	return nil, retAdded
+}
+
+func decodeFilterVulnBody(raw string, target *models.FilterVulnBody) error {
+	allowedFields := map[string]struct{}{
+		"asset_group_ids": {}, "asset_info": {}, "asset_type": {},
+		"business_system_ids": {}, "categorys": {}, "created_time": {},
+		"definiteness": {}, "exposure": {}, "level": {}, "limit": {},
+		"location_ids": {}, "network_region_ids": {}, "offset": {},
+		"project_full_name": {}, "project_id": {}, "related_task_name": {},
+		"status": {}, "tag_ids": {}, "title": {}, "updated_time": {},
+		"xprocess_id": {},
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	var fields map[string]json.RawMessage
+	if err := decoder.Decode(&fields); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values are not allowed")
+		}
+		return err
+	}
+	for name := range fields {
+		if _, ok := allowedFields[name]; !ok {
+			return fmt.Errorf("unknown field %q", name)
+		}
+	}
+	return json.Unmarshal([]byte(raw), target)
 }
 
 // parseOperationVulnerabilityPostVulnFilterResult parses request result and return the string content

--- a/products/xray/cli/post_vuln_filter_operation_test.go
+++ b/products/xray/cli/post_vuln_filter_operation_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chaitin/chaitin-cli/products/xray/client/vulnerability"
+)
+
+func TestPostVulnFilterBodyAcceptsXprocessID(t *testing.T) {
+	t.Parallel()
+	cmd, err := makeOperationVulnerabilityPostVulnFilterCmd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.ParseFlags([]string{`--body={"limit":1,"offset":0,"xprocess_id":1745}`}); err != nil {
+		t.Fatal(err)
+	}
+
+	params := vulnerability.NewPostVulnFilterParams()
+	if err, _ := retrieveOperationVulnerabilityPostVulnFilterBodyFlag(params, "", cmd); err != nil {
+		t.Fatal(err)
+	}
+	if params.Body == nil || params.Body.XprocessID != 1745 {
+		t.Fatalf("xprocess_id = %v, want 1745", params.Body)
+	}
+}
+
+func TestPostVulnFilterBodyRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+	cmd, err := makeOperationVulnerabilityPostVulnFilterCmd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.ParseFlags([]string{`--body={"limit":1,"offset":0,"xprocess_ids":[1745]}`}); err != nil {
+		t.Fatal(err)
+	}
+
+	params := vulnerability.NewPostVulnFilterParams()
+	err, _ = retrieveOperationVulnerabilityPostVulnFilterBodyFlag(params, "", cmd)
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("error = %v, want unknown field error", err)
+	}
+}
+
+func TestPostVulnFilterXprocessIDFlag(t *testing.T) {
+	t.Parallel()
+	cmd, err := makeOperationVulnerabilityPostVulnFilterCmd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.ParseFlags([]string{"--filterVulnBody.xprocess_id=1745"}); err != nil {
+		t.Fatal(err)
+	}
+
+	params := vulnerability.NewPostVulnFilterParams()
+	if err, _ := retrieveOperationVulnerabilityPostVulnFilterBodyFlag(params, "", cmd); err != nil {
+		t.Fatal(err)
+	}
+	if params.Body == nil || params.Body.XprocessID != 1745 {
+		t.Fatalf("xprocess_id = %v, want 1745", params.Body)
+	}
+}

--- a/products/xray/models/filter_report.go
+++ b/products/xray/models/filter_report.go
@@ -24,16 +24,16 @@ type FilterReport struct {
 	CreatedTime *TimeFilterType `json:"created_time,omitempty"`
 
 	// 报表的名称
-	Name []*PartialInputType `json:"name"`
+	Name []*PartialInputType `json:"name,omitempty"`
 
 	// 工作区 id
-	ProjectID []int64 `json:"project_id"`
+	ProjectID []int64 `json:"project_id,omitempty"`
 
 	// 报表状态
-	Status []string `json:"status"`
+	Status []string `json:"status,omitempty"`
 
 	// 报表类型模板
-	Template []string `json:"template"`
+	Template []string `json:"template,omitempty"`
 
 	// 最后更新时间，对应 finished_time
 	UpdatedTime *TimeFilterType `json:"updated_time,omitempty"`
@@ -55,13 +55,13 @@ func (m *FilterReport) UnmarshalJSON(raw []byte) error {
 	var propsFilterReport struct {
 		CreatedTime *TimeFilterType `json:"created_time,omitempty"`
 
-		Name []*PartialInputType `json:"name"`
+		Name []*PartialInputType `json:"name,omitempty"`
 
-		ProjectID []int64 `json:"project_id"`
+		ProjectID []int64 `json:"project_id,omitempty"`
 
-		Status []string `json:"status"`
+		Status []string `json:"status,omitempty"`
 
-		Template []string `json:"template"`
+		Template []string `json:"template,omitempty"`
 
 		UpdatedTime *TimeFilterType `json:"updated_time,omitempty"`
 
@@ -101,13 +101,13 @@ func (m FilterReport) MarshalJSON() ([]byte, error) {
 	var propsFilterReport struct {
 		CreatedTime *TimeFilterType `json:"created_time,omitempty"`
 
-		Name []*PartialInputType `json:"name"`
+		Name []*PartialInputType `json:"name,omitempty"`
 
-		ProjectID []int64 `json:"project_id"`
+		ProjectID []int64 `json:"project_id,omitempty"`
 
-		Status []string `json:"status"`
+		Status []string `json:"status,omitempty"`
 
-		Template []string `json:"template"`
+		Template []string `json:"template,omitempty"`
 
 		UpdatedTime *TimeFilterType `json:"updated_time,omitempty"`
 

--- a/products/xray/models/filter_vuln_body.go
+++ b/products/xray/models/filter_vuln_body.go
@@ -21,58 +21,61 @@ type FilterVulnBody struct {
 	LimitAndOffsetFilter
 
 	// asset group ids
-	AssetGroupIds []int64 `json:"asset_group_ids"`
+	AssetGroupIds []int64 `json:"asset_group_ids,omitempty"`
 
 	// 漏洞资产关联的资产的一些信息，比如对应的 Website 的 URL
-	AssetInfo []*PartialInputType `json:"asset_info"`
+	AssetInfo []*PartialInputType `json:"asset_info,omitempty"`
 
 	// asset type
-	AssetType []string `json:"asset_type"`
+	AssetType []string `json:"asset_type,omitempty"`
 
 	// business system ids
-	BusinessSystemIds []int64 `json:"business_system_ids"`
+	BusinessSystemIds []int64 `json:"business_system_ids,omitempty"`
 
 	// 漏洞分类，请使用/vuln_category/接口获取漏洞分类列表
-	Categorys []string `json:"categorys"`
+	Categorys []string `json:"categorys,omitempty"`
 
 	// created time
 	CreatedTime *TimeFilterType `json:"created_time,omitempty"`
 
 	// 漏洞资产的确信度，疑似是开启漏洞库版本匹配产生的漏洞
-	Definiteness []DefinitenessEnum `json:"definiteness"`
+	Definiteness []DefinitenessEnum `json:"definiteness,omitempty"`
 
 	// 漏洞资产的编号
-	Exposure []*PartialInputType `json:"exposure"`
+	Exposure []*PartialInputType `json:"exposure,omitempty"`
 
 	// 漏洞资产的严重程度
-	Level []SeverityEnum `json:"level"`
+	Level []SeverityEnum `json:"level,omitempty"`
 
 	// location ids
-	LocationIds []int64 `json:"location_ids"`
+	LocationIds []int64 `json:"location_ids,omitempty"`
 
 	// network region ids
-	NetworkRegionIds []int64 `json:"network_region_ids"`
+	NetworkRegionIds []int64 `json:"network_region_ids,omitempty"`
 
 	// project full name
-	ProjectFullName []*PartialInputType `json:"project_full_name"`
+	ProjectFullName []*PartialInputType `json:"project_full_name,omitempty"`
 
 	// 对应的工作区的 ID
 	ProjectID int64 `json:"project_id,omitempty"`
 
 	// 漏洞资产相关联的任务的名字
-	RelatedTaskName []*PartialInputType `json:"related_task_name"`
+	RelatedTaskName []*PartialInputType `json:"related_task_name,omitempty"`
 
 	// 漏洞资产的状态
-	Status []VulnStatusEnum `json:"status"`
+	Status []VulnStatusEnum `json:"status,omitempty"`
 
 	// tag ids
-	TagIds []int64 `json:"tag_ids"`
+	TagIds []int64 `json:"tag_ids,omitempty"`
 
 	// 漏洞资产的标题
-	Title []*PartialInputType `json:"title"`
+	Title []*PartialInputType `json:"title,omitempty"`
 
 	// updated time
 	UpdatedTime *TimeFilterType `json:"updated_time,omitempty"`
+
+	// 任务实例 ID
+	XprocessID int64 `json:"xprocess_id,omitempty"`
 }
 
 // UnmarshalJSON unmarshals this object from a JSON structure
@@ -86,41 +89,43 @@ func (m *FilterVulnBody) UnmarshalJSON(raw []byte) error {
 
 	// now for regular properties
 	var propsFilterVulnBody struct {
-		AssetGroupIds []int64 `json:"asset_group_ids"`
+		AssetGroupIds []int64 `json:"asset_group_ids,omitempty"`
 
-		AssetInfo []*PartialInputType `json:"asset_info"`
+		AssetInfo []*PartialInputType `json:"asset_info,omitempty"`
 
-		AssetType []string `json:"asset_type"`
+		AssetType []string `json:"asset_type,omitempty"`
 
-		BusinessSystemIds []int64 `json:"business_system_ids"`
+		BusinessSystemIds []int64 `json:"business_system_ids,omitempty"`
 
-		Categorys []string `json:"categorys"`
+		Categorys []string `json:"categorys,omitempty"`
 
 		CreatedTime *TimeFilterType `json:"created_time,omitempty"`
 
-		Definiteness []DefinitenessEnum `json:"definiteness"`
+		Definiteness []DefinitenessEnum `json:"definiteness,omitempty"`
 
-		Exposure []*PartialInputType `json:"exposure"`
+		Exposure []*PartialInputType `json:"exposure,omitempty"`
 
-		Level []SeverityEnum `json:"level"`
+		Level []SeverityEnum `json:"level,omitempty"`
 
-		LocationIds []int64 `json:"location_ids"`
+		LocationIds []int64 `json:"location_ids,omitempty"`
 
-		NetworkRegionIds []int64 `json:"network_region_ids"`
+		NetworkRegionIds []int64 `json:"network_region_ids,omitempty"`
 
-		ProjectFullName []*PartialInputType `json:"project_full_name"`
+		ProjectFullName []*PartialInputType `json:"project_full_name,omitempty"`
 
 		ProjectID int64 `json:"project_id,omitempty"`
 
-		RelatedTaskName []*PartialInputType `json:"related_task_name"`
+		RelatedTaskName []*PartialInputType `json:"related_task_name,omitempty"`
 
-		Status []VulnStatusEnum `json:"status"`
+		Status []VulnStatusEnum `json:"status,omitempty"`
 
-		TagIds []int64 `json:"tag_ids"`
+		TagIds []int64 `json:"tag_ids,omitempty"`
 
-		Title []*PartialInputType `json:"title"`
+		Title []*PartialInputType `json:"title,omitempty"`
 
 		UpdatedTime *TimeFilterType `json:"updated_time,omitempty"`
+
+		XprocessID int64 `json:"xprocess_id,omitempty"`
 	}
 	if err := swag.ReadJSON(raw, &propsFilterVulnBody); err != nil {
 		return err
@@ -161,6 +166,8 @@ func (m *FilterVulnBody) UnmarshalJSON(raw []byte) error {
 
 	m.UpdatedTime = propsFilterVulnBody.UpdatedTime
 
+	m.XprocessID = propsFilterVulnBody.XprocessID
+
 	return nil
 }
 
@@ -176,41 +183,43 @@ func (m FilterVulnBody) MarshalJSON() ([]byte, error) {
 
 	// now for regular properties
 	var propsFilterVulnBody struct {
-		AssetGroupIds []int64 `json:"asset_group_ids"`
+		AssetGroupIds []int64 `json:"asset_group_ids,omitempty"`
 
-		AssetInfo []*PartialInputType `json:"asset_info"`
+		AssetInfo []*PartialInputType `json:"asset_info,omitempty"`
 
-		AssetType []string `json:"asset_type"`
+		AssetType []string `json:"asset_type,omitempty"`
 
-		BusinessSystemIds []int64 `json:"business_system_ids"`
+		BusinessSystemIds []int64 `json:"business_system_ids,omitempty"`
 
-		Categorys []string `json:"categorys"`
+		Categorys []string `json:"categorys,omitempty"`
 
 		CreatedTime *TimeFilterType `json:"created_time,omitempty"`
 
-		Definiteness []DefinitenessEnum `json:"definiteness"`
+		Definiteness []DefinitenessEnum `json:"definiteness,omitempty"`
 
-		Exposure []*PartialInputType `json:"exposure"`
+		Exposure []*PartialInputType `json:"exposure,omitempty"`
 
-		Level []SeverityEnum `json:"level"`
+		Level []SeverityEnum `json:"level,omitempty"`
 
-		LocationIds []int64 `json:"location_ids"`
+		LocationIds []int64 `json:"location_ids,omitempty"`
 
-		NetworkRegionIds []int64 `json:"network_region_ids"`
+		NetworkRegionIds []int64 `json:"network_region_ids,omitempty"`
 
-		ProjectFullName []*PartialInputType `json:"project_full_name"`
+		ProjectFullName []*PartialInputType `json:"project_full_name,omitempty"`
 
 		ProjectID int64 `json:"project_id,omitempty"`
 
-		RelatedTaskName []*PartialInputType `json:"related_task_name"`
+		RelatedTaskName []*PartialInputType `json:"related_task_name,omitempty"`
 
-		Status []VulnStatusEnum `json:"status"`
+		Status []VulnStatusEnum `json:"status,omitempty"`
 
-		TagIds []int64 `json:"tag_ids"`
+		TagIds []int64 `json:"tag_ids,omitempty"`
 
-		Title []*PartialInputType `json:"title"`
+		Title []*PartialInputType `json:"title,omitempty"`
 
 		UpdatedTime *TimeFilterType `json:"updated_time,omitempty"`
+
+		XprocessID int64 `json:"xprocess_id,omitempty"`
 	}
 	propsFilterVulnBody.AssetGroupIds = m.AssetGroupIds
 
@@ -247,6 +256,8 @@ func (m FilterVulnBody) MarshalJSON() ([]byte, error) {
 	propsFilterVulnBody.Title = m.Title
 
 	propsFilterVulnBody.UpdatedTime = m.UpdatedTime
+
+	propsFilterVulnBody.XprocessID = m.XprocessID
 
 	jsonDataPropsFilterVulnBody, errFilterVulnBody := swag.WriteJSON(propsFilterVulnBody)
 	if errFilterVulnBody != nil {

--- a/products/xray/models/post_custompoc_update_params_body.go
+++ b/products/xray/models/post_custompoc_update_params_body.go
@@ -61,6 +61,29 @@ type PostCustompocUpdateParamsBody struct {
 	Title string `json:"title,omitempty"`
 }
 
+// MarshalJSON omits optional lists that were not provided while preserving an
+// explicitly provided empty list. The latter is significant for fields such as
+// tags, where [] requests that all existing values be cleared.
+func (m PostCustompocUpdateParamsBody) MarshalJSON() ([]byte, error) {
+	type plainPostCustompocUpdateParamsBody PostCustompocUpdateParamsBody
+
+	data, err := json.Marshal(plainPostCustompocUpdateParamsBody(m))
+	if err != nil {
+		return nil, err
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, err
+	}
+	if m.Exposures == nil {
+		delete(payload, "exposures")
+	}
+	if m.Tags == nil {
+		delete(payload, "tags")
+	}
+	return json.Marshal(payload)
+}
+
 // Validate validates this post custompoc update params body
 func (m *PostCustompocUpdateParamsBody) Validate(formats strfmt.Registry) error {
 	var res []error

--- a/products/xray/models/request_serialization_test.go
+++ b/products/xray/models/request_serialization_test.go
@@ -1,0 +1,93 @@
+package models
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+)
+
+func TestFilterVulnBodyOmitsUnsetSlices(t *testing.T) {
+	t.Parallel()
+	limit, offset := int64(3), int64(0)
+	body := FilterVulnBody{
+		LimitAndOffsetFilter: LimitAndOffsetFilter{Limit: &limit, Offset: &offset},
+		ProjectID:            1,
+		Status:               []VulnStatusEnum{},
+		XprocessID:           1745,
+	}
+
+	assertJSONEquals(t, body, map[string]any{
+		"limit":       float64(3),
+		"offset":      float64(0),
+		"project_id":  float64(1),
+		"xprocess_id": float64(1745),
+	})
+}
+
+func TestFilterReportOmitsUnsetSlices(t *testing.T) {
+	t.Parallel()
+	limit, offset := int64(10), int64(0)
+	body := FilterReport{CommonFilter: CommonFilter{
+		LimitAndOffsetFilter: LimitAndOffsetFilter{Limit: &limit, Offset: &offset},
+	}}
+
+	assertJSONEquals(t, body, map[string]any{"limit": float64(10), "offset": float64(0)})
+}
+
+func TestPostCustompocUpdateParamsBodyOptionalSlices(t *testing.T) {
+	t.Parallel()
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000001")
+
+	t.Run("unset lists are omitted", func(t *testing.T) {
+		assertJSONEquals(t, PostCustompocUpdateParamsBody{CustomPocID: &id}, map[string]any{
+			"custom_poc_id": string(id),
+		})
+	})
+	t.Run("explicit empty lists are preserved", func(t *testing.T) {
+		assertJSONEquals(t, PostCustompocUpdateParamsBody{
+			CustomPocID: &id,
+			Exposures:   []string{},
+			Tags:        []strfmt.UUID{},
+		}, map[string]any{
+			"custom_poc_id": string(id),
+			"exposures":     []any{},
+			"tags":          []any{},
+		})
+	})
+	t.Run("populated lists are preserved", func(t *testing.T) {
+		tag := strfmt.UUID("00000000-0000-0000-0000-000000000002")
+		assertJSONEquals(t, PostCustompocUpdateParamsBody{
+			CustomPocID: &id,
+			Exposures:   []string{"CVE-2026-0001"},
+			Tags:        []strfmt.UUID{tag},
+		}, map[string]any{
+			"custom_poc_id": string(id),
+			"exposures":     []any{"CVE-2026-0001"},
+			"tags":          []any{string(tag)},
+		})
+	})
+}
+
+func TestDeleteCustompocParamsBodyRemainsRequired(t *testing.T) {
+	t.Parallel()
+	if err := (&DeleteCustompocParamsBody{}).Validate(strfmt.Default); err == nil {
+		t.Fatal("expected custom_poc_id_list to remain required")
+	}
+}
+
+func assertJSONEquals(t *testing.T, value any, want map[string]any) {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSON = %s, want %#v", encoded, want)
+	}
+}


### PR DESCRIPTION
## Changes

- omit unset slice filters from `FilterVulnBody` and `FilterReport` request JSON instead of sending `null`
- add the current OpenAPI `xprocess_id` field and CLI flag to vulnerability filtering
- reject unknown fields in `PostVulnFilter --body`, preventing `xprocess_ids` from being silently ignored
- omit unset custom POC update lists while preserving explicit empty arrays such as `tags: []`
- keep required delete request arrays unchanged
- add serialization and CLI regression tests

## Why

X-Ray's Django REST Framework serializers accept omitted optional list filters but reject explicit `null`. The generated Go request models serialized nil slices as `null`, causing `PostVulnFilter`, `PostReportFilter`, and related request paths to fail with `INVALID_PAYLOAD`.

## Impact

- minimal vulnerability and report filter requests now work normally
- existing populated list filters are unchanged
- explicit empty custom POC tag lists remain available for clearing tags
- invalid `xprocess_ids` input now fails locally; callers should use singular `xprocess_id`
- no configuration or credential changes

## Root cause

The generated request models had inconsistent JSON tags and custom marshal structures for optional slices. The vulnerability model was also behind the current OpenAPI definition and omitted `xprocess_id`.

## Checks

- `task test`
- `task lint`
- `task build`
- `git diff --check`
- test environment: `PostVulnFilter` minimal body, populated `status` slice, `xprocess_id`, and CLI flag paths
- test environment: `PostReportFilter` minimal body and populated `status` slice
- dry-run: custom POC update omits nil lists and preserves explicit empty lists
