### PR TITLE
enforce required xray flags

### DIFF
--- a/products/xray/command.go
+++ b/products/xray/command.go
@@ -1,16 +1,107 @@
 package xray
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/chaitin/chaitin-cli/config"
 	"github.com/chaitin/chaitin-cli/products/xray/cli"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func NewCommand() (*cobra.Command, error) {
-	return cli.MakeCommand()
+	cmd, err := cli.MakeCommand()
+	if err != nil {
+		return nil, err
+	}
+	if err := configureRequiredFlags(cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
 }
 
 func ApplyRuntimeConfig(cmd *cobra.Command, cfg config.Raw, dryRun bool) {
 	_ = cmd
 	cli.SetRuntimeConfig(cfg, dryRun)
+}
+
+// configureRequiredFlags restores required-parameter semantics that are only
+// emitted as help text by go-swagger's generated Cobra commands. Model flags
+// contain a dot-qualified prefix and are deliberately excluded because users
+// may provide the same required fields through --body instead.
+func configureRequiredFlags(root *cobra.Command) error {
+	if err := configureCommandRequiredFlags(root); err != nil {
+		return err
+	}
+	return configureRequiredFlagsForChildren(root)
+}
+
+func configureRequiredFlagsForChildren(parent *cobra.Command) error {
+	for _, cmd := range parent.Commands() {
+		if err := configureCommandRequiredFlags(cmd); err != nil {
+			return err
+		}
+		if err := configureRequiredFlagsForChildren(cmd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func configureCommandRequiredFlags(cmd *cobra.Command) error {
+	var markErr error
+	cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		if markErr != nil || strings.Contains(flag.Name, ".") || !strings.HasPrefix(flag.Usage, "Required.") {
+			return
+		}
+		markErr = cobra.MarkFlagRequired(cmd.PersistentFlags(), flag.Name)
+	})
+	if markErr != nil {
+		return fmt.Errorf("configure required flags for %s: %w", cmd.CommandPath(), markErr)
+	}
+
+	if cmd.Run == nil && cmd.RunE == nil {
+		return nil
+	}
+	previousPreRunE := cmd.PreRunE
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if previousPreRunE != nil {
+			if err := previousPreRunE(cmd, args); err != nil {
+				return err
+			}
+		}
+		return validatePositiveResourceIDs(cmd)
+	}
+	return nil
+}
+
+func validatePositiveResourceIDs(cmd *cobra.Command) error {
+	var validationErr error
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if validationErr != nil || !flag.Changed || !isRequiredResourceID(flag) {
+			return
+		}
+		value, err := strconv.ParseInt(flag.Value.String(), 10, 64)
+		if err != nil {
+			validationErr = fmt.Errorf("invalid --%s: %w", flag.Name, err)
+			return
+		}
+		if value <= 0 {
+			validationErr = fmt.Errorf("--%s must be greater than zero", flag.Name)
+		}
+	})
+	return validationErr
+}
+
+func isRequiredResourceID(flag *pflag.Flag) bool {
+	if flag.Value.Type() != "int" && flag.Value.Type() != "int64" {
+		return false
+	}
+	if _, required := flag.Annotations[cobra.BashCompOneRequiredFlag]; !required {
+		return false
+	}
+	name := strings.ReplaceAll(flag.Name, "-", "_")
+	return name == "id" || strings.HasSuffix(name, "_id")
 }

--- a/products/xray/command_test.go
+++ b/products/xray/command_test.go
@@ -1,0 +1,95 @@
+package xray
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestGeneratedOperationRequiredFlagsAreMarked(t *testing.T) {
+	cmd := newTestCommand(t)
+	requiredCount := 0
+	visitCommands(cmd, func(command *cobra.Command) {
+		command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+			if strings.Contains(flag.Name, ".") || !strings.HasPrefix(flag.Usage, "Required.") {
+				return
+			}
+			requiredCount++
+			if _, ok := flag.Annotations[cobra.BashCompOneRequiredFlag]; !ok {
+				t.Errorf("%s --%s is not marked required", command.CommandPath(), flag.Name)
+			}
+		})
+	})
+	if requiredCount == 0 {
+		t.Fatal("expected generated required operation flags")
+	}
+}
+
+func TestDeletePlanRequiredID(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "missing", args: []string{"plan", "DeletePlanID"}, wantErr: `required flag(s) "id" not set`},
+		{name: "zero", args: []string{"plan", "DeletePlanID", "--id=0"}, wantErr: "--id must be greater than zero"},
+		{name: "valid", args: []string{"plan", "DeletePlanID", "--id=1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newTestCommand(t)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequiredBodyModelFlagsAreNotMarked(t *testing.T) {
+	cmd := newTestCommand(t)
+	found := false
+	visitCommands(cmd, func(command *cobra.Command) {
+		command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+			if !strings.Contains(flag.Name, ".") || !strings.HasPrefix(flag.Usage, "Required.") {
+				return
+			}
+			found = true
+			if _, marked := flag.Annotations[cobra.BashCompOneRequiredFlag]; marked {
+				t.Errorf("body model flag --%s must not be marked required", flag.Name)
+			}
+		})
+	})
+	if !found {
+		t.Fatal("expected at least one required body model flag")
+	}
+}
+
+func newTestCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+	t.Setenv("XRAY_URL", "https://example.invalid/api/v2")
+	cmd, err := NewCommand()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ApplyRuntimeConfig(cmd, nil, true)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	return cmd
+}
+
+func visitCommands(command *cobra.Command, visit func(*cobra.Command)) {
+	visit(command)
+	for _, child := range command.Commands() {
+		visitCommands(child, visit)
+	}
+}


### PR DESCRIPTION
## Changes

- restore Cobra required semantics for generated X-Ray operation-level path and query flags
- reject explicitly provided zero or negative numeric resource IDs
- preserve `--body` compatibility by excluding dot-qualified model flags from Cobra required annotations
- add command-tree and end-to-end dry-run regression tests

## Why

The generated X-Ray CLI only included `Required.` in flag help text. It never called `MarkFlagRequired`, so destructive and update commands could proceed through dry-run with missing IDs and exit successfully.

## Impact

- missing required path/query flags now fail before `RunE`, including during dry-run
- numeric resource IDs such as `--id=0` are rejected locally
- valid zero-valued non-ID parameters such as `--offset=0` remain supported
- body model flags are not marked individually, so callers may continue using `--body`
- this PR does not overlap files changed by #71

## Root cause

go-swagger's generated Cobra layer emitted required metadata only as help text, while the generated API parameter types also represented required numeric path parameters as zero-valued scalars without validation.

## Checks

- `task test`
- `task lint`
- `task build`
- `git diff --check`
- dry-run: missing `DeletePlanID --id` exits 1
- dry-run: `DeletePlanID --id=0` exits 1
- dry-run: valid ID exits 0
- dry-run: `GetProject --offset=0` remains valid and missing offset exits 1
- test environment: valid `GetPlanID`, `GetProject`, `GetTemplateID`, and project-scoped query requests succeed

## Follow-up

Body model validation should be handled separately after #71; marking every generated model flag required would incorrectly break valid `--body` requests.
