### PR TITLE
fix cloudatlas url flag collision

### DIFF
--- a/products/cloudatlas/command.go
+++ b/products/cloudatlas/command.go
@@ -38,8 +38,8 @@ Config example:
 		},
 	}
 
-	cmd.PersistentFlags().String("url", "", "Cloud Atlas OpenAPI base URL；也可配置 cloudAtlas.url 或 CLOUD_ATLAS_URL")
-	cmd.PersistentFlags().String("token", "", "Cloud Atlas API token；请求时作为 TOKEN header 发送，也可配置 cloudAtlas.token 或 CLOUD_ATLAS_TOKEN")
+	cmd.PersistentFlags().String("url", "", "Cloud Atlas OpenAPI base URL；也可配置 cloudAtlas.url 或 CLOUDATLAS_URL")
+	cmd.PersistentFlags().String("token", "", "Cloud Atlas API token；请求时作为 TOKEN header 发送，也可配置 cloudAtlas.token 或 CLOUDATLAS_TOKEN")
 	cmd.PersistentFlags().String("space-id", "", "Cloud Atlas 空间 ID；作为所有请求的 space query 默认值，也可配置 cloudAtlas.space_id；子命令 --space 可覆盖")
 	cmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "输出格式；可选值: table, json")
 	cmd.PersistentFlags().BoolVar(&runtimeInsecure, "insecure", true, "跳过 TLS 证书校验；测试或自签名环境使用，默认 true")

--- a/products/cloudatlas/command_test.go
+++ b/products/cloudatlas/command_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/chaitin/chaitin-cli/config"
+	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 
@@ -77,6 +78,68 @@ func TestListUsesConfiguredSpaceID(t *testing.T) {
 	ApplyRuntimeConfig(nil, rawConfig(Config{URL: server.URL, Token: "secret-token", SpaceID: "42"}), false)
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"asset", "ip", "list", "--status", "valid"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestWebsiteFingerprintListURLIsNotALocalFlag(t *testing.T) {
+	cmd := NewCommand()
+	leaf := findLeaf(t, cmd, "exposure", "website-fingerprint", "list")
+	if got := leaf.LocalFlags().Lookup("url"); got != nil {
+		t.Fatalf("--url should not be registered as a local query flag")
+	}
+	if got := leaf.Flags().Lookup("url"); got == nil {
+		t.Fatalf("--url should still be available as the base URL flag")
+	}
+}
+
+func TestWebsiteFingerprintListURLFlagDoesNotBecomeQueryParameter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/attack/appfinger" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("TOKEN"); got != "secret-token" {
+			t.Fatalf("TOKEN = %q", got)
+		}
+		if got := r.URL.Query().Get("space"); got != "35" {
+			t.Fatalf("space = %q", got)
+		}
+		if r.URL.Query().Has("url") {
+			t.Fatalf("url query parameter should not be set from --url, got %q", r.URL.Query().Get("url"))
+		}
+		writeJSON(t, w, map[string]any{"code": 200, "message": "", "data": map[string]any{"current": 1, "size": 3, "total": 0, "items": []any{}}})
+	}))
+	defer server.Close()
+
+	ApplyRuntimeConfig(nil, rawConfig(Config{Token: "secret-token"}), false)
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"exposure", "website-fingerprint", "list", "--url", server.URL, "--space-id", "35", "--page", "1", "--size", "3"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestWebsiteFingerprintListURLFilterViaQueryFlag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/attack/appfinger" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("space"); got != "35" {
+			t.Fatalf("space = %q", got)
+		}
+		if got := r.URL.Query().Get("url"); got != "foo" {
+			t.Fatalf("url query parameter = %q, want foo", got)
+		}
+		writeJSON(t, w, map[string]any{"code": 200, "message": "", "data": map[string]any{"current": 1, "size": 3, "total": 0, "items": []any{}}})
+	}))
+	defer server.Close()
+
+	ApplyRuntimeConfig(nil, rawConfig(Config{Token: "secret-token"}), false)
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"exposure", "website-fingerprint", "list", "--url", server.URL, "--space-id", "35", "--query", "url=foo", "--page", "1", "--size", "3"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -244,6 +307,25 @@ func TestRequestBodyHelpExplainsFields(t *testing.T) {
 			t.Fatalf("body help missing %q:\n%s", want, help)
 		}
 	}
+}
+
+func findLeaf(t *testing.T, root *cobra.Command, path ...string) *cobra.Command {
+	t.Helper()
+	current := root
+	for _, name := range path {
+		var next *cobra.Command
+		for _, child := range current.Commands() {
+			if child.Name() == name {
+				next = child
+				break
+			}
+		}
+		if next == nil {
+			t.Fatalf("command %q not found under %q", name, current.Name())
+		}
+		current = next
+	}
+	return current
 }
 
 func rawConfig(value Config) config.Raw {

--- a/products/cloudatlas/parser.go
+++ b/products/cloudatlas/parser.go
@@ -280,6 +280,9 @@ func (p *Parser) createOperationCommand(use, method, path string, op *Operation)
 			continue
 		}
 		flagName := normalizeFlagName(param.Name)
+		if param.In == "query" && isReservedFlagName(flagName) {
+			continue
+		}
 		required := param.Required || (param.In == "query" && flagName == "space")
 		cmd.Flags().String(flagName, "", formatParameterUsage(param, required))
 	}
@@ -363,6 +366,9 @@ func buildQuery(cmd *cobra.Command, params []Parameter) (url.Values, error) {
 			continue
 		}
 		flagName := normalizeFlagName(param.Name)
+		if isReservedFlagName(flagName) {
+			continue
+		}
 		if flagName == "space" {
 			spaceHandled = true
 		}
@@ -511,7 +517,12 @@ func buildOperationHelp(method, path string, op *Operation) string {
 		fmt.Fprintln(&b, "\nParameters:")
 		for _, param := range op.Parameters {
 			required := param.Required || (param.In == "query" && normalizeFlagName(param.Name) == "space")
-			fmt.Fprintf(&b, "  --%s (%s): %s\n", normalizeFlagName(param.Name), param.In, formatParameterUsage(param, required))
+			flagName := normalizeFlagName(param.Name)
+			if param.In == "query" && isReservedFlagName(flagName) {
+				fmt.Fprintf(&b, "  --query %s=<value> (%s，透传): %s\n", param.Name, param.In, formatParameterUsage(param, required))
+				continue
+			}
+			fmt.Fprintf(&b, "  --%s (%s): %s\n", flagName, param.In, formatParameterUsage(param, required))
 		}
 	}
 	if op.RequestBody != nil {
@@ -706,6 +717,22 @@ func valueHelp(value any) string {
 
 func normalizeFlagName(name string) string {
 	return strings.ReplaceAll(normalizeSegment(name), "_", "-")
+}
+
+var reservedFlagNames = map[string]bool{
+	"url":               true,
+	"token":             true,
+	"space-id":          true,
+	"output":            true,
+	"insecure":          true,
+	"verbose":           true,
+	"verbose-sensitive": true,
+	"config":            true,
+	"dry-run":           true,
+}
+
+func isReservedFlagName(name string) bool {
+	return reservedFlagNames[name]
 }
 
 func normalizeSegment(value string) string {


### PR DESCRIPTION
ISSUE:https://github.com/chaitin/chaitin-cli/issues/73

**问题**
cloudAtlas exposure website-fingerprint list（GET /v1/attack/appfinger）中，CLI 全局 flag --url（API 基址）与接口查询参数 url（按 URL 模糊查询）同名。命令生成器把接口的 url 参数绑定成子命令本地 --url，遮蔽了基址 flag，导致传 --url https://.../openapi 时，这个值被同时当成查询参数 url 发送，服务端按“URL 包含 API 地址”过滤，返回错误结果。
复现时，实测同一空间，正确结果 total=3398，撞名后只剩 total=1（甚至 0）。

**修复内容**
新增保留 flag 名集合：url/token/space-id/output/insecure/verbose/verbose-sensitive/config/dry-run。
createOperationCommand 遇到撞名的 query 参数时，不再自动注册本地 flag。
buildQuery 跳过保留参数，改由现有 --query key=value 透传，例如：--query 'url=https://example.com:5001'

--help 中撞名参数显示为 --query url=<value> (query，透传)。
修正环境变量文案：CLOUD_ATLAS_URL → CLOUDATLAS_URL、CLOUD_ATLAS_TOKEN → CLOUDATLAS_TOKEN。
新增 3 个回归测试，覆盖本地 flag 不再注册、--url 不进入 query、--query url=... 正常透传。

**影响范围**
--url 仍然作为 API 基址使用，行为不变。
website-fingerprint list 的 url 过滤参数改为通过 --query url=value 显式传入。

**同类问题review**
检查了用于生成参数的OpenAPI spec，全 spec 共 549 个 query/path 参数，只有上述一个url参数 1 处存在与环境参数冲突