### PR TITLE
fix(apisec): load embedded schemas on Windows

### DIFF
--- a/products/apisec/schema_loader.go
+++ b/products/apisec/schema_loader.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -39,7 +39,7 @@ func loadEmbeddedSchema() (*OpenAPI, *CLIMapping, error) {
 		return nil, nil, fmt.Errorf("latest APISec schema version is empty")
 	}
 
-	openAPIData, err := schemaFS.ReadFile(filepath.Join(version, "openapi.json"))
+	openAPIData, err := schemaFS.ReadFile(path.Join(version, "openapi.json"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("read APISec OpenAPI for %s: %w", version, err)
 	}
@@ -48,7 +48,7 @@ func loadEmbeddedSchema() (*OpenAPI, *CLIMapping, error) {
 		return nil, nil, err
 	}
 
-	mappingData, err := schemaFS.ReadFile(filepath.Join(version, "cli-mapping.yaml"))
+	mappingData, err := schemaFS.ReadFile(path.Join(version, "cli-mapping.yaml"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("read APISec CLI mapping for %s: %w", version, err)
 	}


### PR DESCRIPTION
## Problem

On Windows, APISec cannot load its embedded OpenAPI schema or CLI mapping. filepath.Join produces paths such as v26.05\openapi.json, but embed.FS follows the io/fs contract and accepts slash-separated paths only. This prevents the dynamic APISec command tree from being registered in Windows builds.

## Cause

The embedded resource names were constructed with the OS-specific path/filepath package instead of the slash-based path package required by io/fs.

## Change

Use path.Join for both embedded schema resource paths. No filesystem paths or runtime API behavior are otherwise changed.

## Validation

- go test ./products/apisec (Windows; passes, and failed with the embedded-path error before this change)
- go vet ./...
- go build -o chaitin-cli.exe .
- go test ./... (APISec and all other packages pass; the existing config package still has three unrelated Windows-only failures from POSIX mode and symlink privilege assumptions)